### PR TITLE
use project id as external-name

### DIFF
--- a/apis/projects/v1alpha1/project_types.go
+++ b/apis/projects/v1alpha1/project_types.go
@@ -419,11 +419,11 @@ type ProjectStatus struct {
 
 // +kubebuilder:object:root=true
 
-// A Project is a managed resource that represents an AWS Elastic Kubernetes
-// Service Project.
+// A Project is a managed resource that represents a Gitlab Project
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="PATH WITH NAMESPACE",type="string",JSONPath=".status.atProvider.pathWithNamespace"
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,gitlab}
 type Project struct {

--- a/package/crds/projects.gitlab.crossplane.io_projects.yaml
+++ b/package/crds/projects.gitlab.crossplane.io_projects.yaml
@@ -16,6 +16,9 @@ spec:
   - JSONPath: .metadata.creationTimestamp
     name: AGE
     type: date
+  - JSONPath: .status.atProvider.pathWithNamespace
+    name: PATH WITH NAMESPACE
+    type: string
   group: projects.gitlab.crossplane.io
   names:
     categories:
@@ -31,7 +34,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: A Project is a managed resource that represents an AWS Elastic Kubernetes Service Project.
+      description: A Project is a managed resource that represents a Gitlab Project
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'


### PR DESCRIPTION
### Description of your changes

- use project id instead of path/name combination as `external-name`, which makes creating a project referencer easier (e.g. for project hooks)
- drop tests for updating external-name

Note that this is a breaking change but given that we don't have a release yet I think we can get away with it

Fixes #7 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
manually created a `project` without setting an `annotation` and deleting it again.