### PR TITLE
Add name field to group and project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ crds.clean:
 	@find package/crds -name *.yaml.sed -delete || $(FAIL)
 	@$(OK) cleaned generated CRDs
 
-generate: crds.clean
+generate.done: crds.clean
 
 # Ensure a PR is ready for review.
 reviewable: generate lint

--- a/apis/groups/v1alpha1/group_types.go
+++ b/apis/groups/v1alpha1/group_types.go
@@ -73,6 +73,12 @@ type GroupParameters struct {
 	// +optional
 	Description *string `json:"description,omitempty"`
 
+	// Name is the human-readable name of the group.
+	// If set, it overrides metadata.name.
+	// +kubebuilder:validation:MaxLength:=255
+	// +optional
+	Name *string `json:"name,omitempty"`
+
 	// Prevent adding new members to project membership within this group.
 	// +optional
 	MembershipLock *bool `json:"membershipLock,omitempty"`

--- a/apis/groups/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/groups/v1alpha1/zz_generated.deepcopy.go
@@ -300,6 +300,11 @@ func (in *GroupParameters) DeepCopyInto(out *GroupParameters) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Name != nil {
+		in, out := &in.Name, &out.Name
+		*out = new(string)
+		**out = **in
+	}
 	if in.MembershipLock != nil {
 		in, out := &in.MembershipLock, &out.MembershipLock
 		*out = new(bool)

--- a/apis/projects/v1alpha1/project_types.go
+++ b/apis/projects/v1alpha1/project_types.go
@@ -220,6 +220,12 @@ type ProjectParameters struct {
 	// +optional
 	Description *string `json:"description,omitempty"`
 
+	// Name is the human-readable name of the project.
+	// If set, it overrides metadata.name.
+	// +kubebuilder:validation:MaxLength:=255
+	// +optional
+	Name *string `json:"name,omitempty"`
+
 	// Disable email notifications.
 	// +optional
 	EmailsDisabled *bool `json:"emailsDisabled,omitempty"`

--- a/apis/projects/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/projects/v1alpha1/zz_generated.deepcopy.go
@@ -797,6 +797,11 @@ func (in *ProjectParameters) DeepCopyInto(out *ProjectParameters) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Name != nil {
+		in, out := &in.Name, &out.Name
+		*out = new(string)
+		**out = **in
+	}
 	if in.EmailsDisabled != nil {
 		in, out := &in.EmailsDisabled, &out.EmailsDisabled
 		*out = new(bool)

--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -137,9 +137,9 @@ eval $(make --no-print-directory -C ${projectdir} build.vars)
 
 # ------------------------------
 
-HOSTARCH="${HOSTARCH:-amd64}"
-BUILD_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-${HOSTARCH}"
-CONTROLLER_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-controller-${HOSTARCH}"
+SAFEHOSTARCH="${SAFEHOSTARCH:-amd64}"
+BUILD_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-${SAFEHOSTARCH}"
+CONTROLLER_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-controller-${SAFEHOSTARCH}"
 
 version_tag="$(cat ${projectdir}/_output/version)"
 # tag as latest version to load into kind cluster

--- a/examples/groups/group.yaml
+++ b/examples/groups/group.yaml
@@ -4,6 +4,8 @@ metadata:
   name: example-group
 spec:
   forProvider:
+    # If not set, metadata.name will be used instead.
+    name: "Example Group"
     parentIdRef:
       name: example-parent-group
     path: "example-group-path"

--- a/examples/projects/project.yaml
+++ b/examples/projects/project.yaml
@@ -4,6 +4,7 @@ metadata:
   name: example-project
 spec:
   forProvider:
+    name: "Example Project" # Overrides metadata.name
     namespaceIdRef:
       name: example-group
     description: "example project description"

--- a/examples/projects/project.yaml
+++ b/examples/projects/project.yaml
@@ -4,7 +4,8 @@ metadata:
   name: example-project
 spec:
   forProvider:
-    name: "Example Project" # Overrides metadata.name
+    # If not set, metadata.name will be used instead.
+    name: "Example Project"
     namespaceIdRef:
       name: example-group
     description: "example project description"

--- a/package/crds/groups.gitlab.crossplane.io_groups.yaml
+++ b/package/crds/groups.gitlab.crossplane.io_groups.yaml
@@ -77,6 +77,10 @@ spec:
                   mentionsDisabled:
                     description: Disable the capability of a group from getting mentioned.
                     type: boolean
+                  name:
+                    description: Name is the human-readable name of the group. If set, it overrides metadata.name.
+                    maxLength: 255
+                    type: string
                   parentId:
                     description: The parent group ID for creating nested group.
                     type: integer

--- a/package/crds/projects.gitlab.crossplane.io_projects.yaml
+++ b/package/crds/projects.gitlab.crossplane.io_projects.yaml
@@ -171,6 +171,10 @@ spec:
                   mirrorUserId:
                     description: User responsible for all the activity surrounding a pull mirror event. (admins only)
                     type: integer
+                  name:
+                    description: Name is the human-readable name of the project. If set, it overrides metadata.name.
+                    maxLength: 255
+                    type: string
                   namespaceId:
                     description: Namespace for the new project (defaults to the current user’s namespace).
                     type: integer

--- a/pkg/clients/groups/group.go
+++ b/pkg/clients/groups/group.go
@@ -134,6 +134,10 @@ func GenerateObservation(grp *gitlab.Group) v1alpha1.GroupObservation { // nolin
 
 // GenerateCreateGroupOptions generates group creation options
 func GenerateCreateGroupOptions(name string, p *v1alpha1.GroupParameters) *gitlab.CreateGroupOptions {
+	// Name field overrides resource name
+	if p.Name != nil {
+		name = *p.Name
+	}
 	group := &gitlab.CreateGroupOptions{
 		Name:                           &name,
 		Path:                           &p.Path,
@@ -160,6 +164,10 @@ func GenerateCreateGroupOptions(name string, p *v1alpha1.GroupParameters) *gitla
 
 // GenerateEditGroupOptions generates group edit options
 func GenerateEditGroupOptions(name string, p *v1alpha1.GroupParameters) *gitlab.UpdateGroupOptions {
+	// Name field overrides resource name
+	if p.Name != nil {
+		name = *p.Name
+	}
 	group := &gitlab.UpdateGroupOptions{
 		Name:                           &name,
 		Path:                           &p.Path,

--- a/pkg/clients/projects/project.go
+++ b/pkg/clients/projects/project.go
@@ -264,6 +264,10 @@ func GenerateObservation(prj *gitlab.Project) v1alpha1.ProjectObservation { // n
 
 // GenerateCreateProjectOptions generates project creation options
 func GenerateCreateProjectOptions(name string, p *v1alpha1.ProjectParameters) *gitlab.CreateProjectOptions {
+	// Name field overrides resource name
+	if p.Name != nil {
+		name = *p.Name
+	}
 	project := &gitlab.CreateProjectOptions{
 		Name:                                &name,
 		Path:                                p.Path,
@@ -325,6 +329,10 @@ func GenerateCreateProjectOptions(name string, p *v1alpha1.ProjectParameters) *g
 
 // GenerateEditProjectOptions generates project edit options
 func GenerateEditProjectOptions(name string, p *v1alpha1.ProjectParameters) *gitlab.EditProjectOptions {
+	// Name field overrides resource name
+	if p.Name != nil {
+		name = *p.Name
+	}
 	o := &gitlab.EditProjectOptions{
 		Name:                                &name,
 		Path:                                p.Path,

--- a/pkg/clients/projects/project_test.go
+++ b/pkg/clients/projects/project_test.go
@@ -30,6 +30,7 @@ import (
 
 var (
 	name                             = "my-project"
+	overrideName                     = "My Project"
 	path                             = "path/to/project"
 	namespaceID                      = 1
 	defaultBranch                    = "main"
@@ -571,6 +572,21 @@ func TestGenerateCreateProjectOptions(t *testing.T) {
 				BuildTimeout:                   &buildTimeout,
 			},
 		},
+		"NameOverride": {
+			args: args{
+				name: name,
+				parameters: &v1alpha1.ProjectParameters{
+					Name: &overrideName,
+					// TODO: TagList specified and wanted because otherwise
+					// test does not pass - (nil vs &nil - fix)
+					TagList: tagList,
+				},
+			},
+			want: &gitlab.CreateProjectOptions{
+				Name:    &overrideName,
+				TagList: &tagList,
+			},
+		},
 	}
 
 	for name, tc := range cases {
@@ -722,6 +738,21 @@ func TestGenerateEditProjectOptions(t *testing.T) {
 				MergeMethod:                    clients.MergeMethodStringToGitlab(mergeMethod),
 				TagList:                        &tagList,
 				BuildTimeout:                   &buildTimeout,
+			},
+		},
+		"NameOverride": {
+			args: args{
+				name: name,
+				parameters: &v1alpha1.ProjectParameters{
+					Name: &name,
+					// TODO: TagList specified and wanted because otherwise
+					// test does not pass - (nil vs &nil - fix)
+					TagList: tagList,
+				},
+			},
+			want: &gitlab.EditProjectOptions{
+				Name:    &name,
+				TagList: &tagList,
 			},
 		},
 	}


### PR DESCRIPTION
### Description of your changes

Adds a new `name` field to `Group` and `Project` resources - this allows users to set a 'human readable' name for their `Group` or `Project` that is free of the restrictions placed on the `metadata.name` of a resource.

Closes #41

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
An additional test has been added to each resource to validate the override behaviour of the `name` field.

[contribution process]: https://git.io/fj2m9
