### PR TITLE
Make sure project and group name is checked for updates

### DIFF
--- a/pkg/controller/groups/group.go
+++ b/pkg/controller/groups/group.go
@@ -164,6 +164,9 @@ func (e *external) Delete(ctx context.Context, mg resource.Managed) error {
 
 // isGroupUpToDate checks whether there is a change in any of the modifiable fields.
 func isGroupUpToDate(p *v1alpha1.GroupParameters, g *gitlab.Group) bool { // nolint:gocyclo
+	if p.Name != nil && !cmp.Equal(*p.Name, g.Name) {
+		return false
+	}
 	if !cmp.Equal(p.Path, g.Path) {
 		return false
 	}

--- a/pkg/controller/groups/group.go
+++ b/pkg/controller/groups/group.go
@@ -179,6 +179,12 @@ func isGroupUpToDate(p *v1alpha1.GroupParameters, g *gitlab.Group) bool { // nol
 	if (p.Visibility != nil) && (!cmp.Equal(string(*p.Visibility), string(g.Visibility))) {
 		return false
 	}
+	if (p.ProjectCreationLevel != nil) && (!cmp.Equal(string(*p.ProjectCreationLevel), string(g.ProjectCreationLevel))) {
+		return false
+	}
+	if (p.SubGroupCreationLevel != nil) && (!cmp.Equal(string(*p.SubGroupCreationLevel), string(g.SubGroupCreationLevel))) {
+		return false
+	}
 	if !clients.IsBoolEqualToBoolPtr(p.ShareWithGroupLock, g.ShareWithGroupLock) {
 		return false
 	}

--- a/pkg/controller/groups/group_test.go
+++ b/pkg/controller/groups/group_test.go
@@ -360,6 +360,7 @@ func TestObserve(t *testing.T) {
 	}
 
 	isGroupUpToDateCases := map[string]interface{}{
+		"Name":                           "name",
 		"Path":                           "/new/group/path",
 		"Description":                    "description v2",
 		"MembershipLock":                 true,

--- a/pkg/controller/projects/project.go
+++ b/pkg/controller/projects/project.go
@@ -273,6 +273,9 @@ func lateInitialize(in *v1alpha1.ProjectParameters, project *gitlab.Project) { /
 
 // isProjectUpToDate checks whether there is a change in any of the modifiable fields.
 func isProjectUpToDate(p *v1alpha1.ProjectParameters, g *gitlab.Project) bool { // nolint:gocyclo
+	if p.Name != nil && !cmp.Equal(*p.Name, g.Name) {
+		return false
+	}
 	if !clients.IsBoolEqualToBoolPtr(p.AllowMergeOnSkippedPipeline, g.AllowMergeOnSkippedPipeline) {
 		return false
 	}

--- a/pkg/controller/projects/project_test.go
+++ b/pkg/controller/projects/project_test.go
@@ -343,6 +343,7 @@ func TestObserve(t *testing.T) {
 	visibility := v1alpha1.PublicVisibility
 
 	projectParameters := v1alpha1.ProjectParameters{
+		Name:                             &s,
 		Path:                             &s,
 		DefaultBranch:                    &s,
 		Description:                      &s,
@@ -392,6 +393,7 @@ func TestObserve(t *testing.T) {
 			withConditions(xpv1.Available()),
 		}
 		gitlabProject := &gitlab.Project{
+			Name:                             s,
 			Path:                             s,
 			DefaultBranch:                    s,
 			Description:                      s,
@@ -435,7 +437,7 @@ func TestObserve(t *testing.T) {
 		val := reflect.ValueOf(value)
 
 		structFieldValue.Set(val)
-		cases["IsGroupUpToDate"+name] = struct {
+		cases["IsProjectUpToDate"+name] = struct {
 			args
 			want
 		}{

--- a/pkg/controller/projects/project_test.go
+++ b/pkg/controller/projects/project_test.go
@@ -295,6 +295,7 @@ func TestObserve(t *testing.T) {
 	}
 
 	isProjectUpToDateCases := map[string]interface{}{
+		"Name":                                      "name",
 		"Path":                                      "path",
 		"DefaultBranch":                             "Default branch",
 		"Description":                               "description",


### PR DESCRIPTION
### Description of your changes
Forgot to implement up to date checking of the new `name` fields added in #42.

This adds additional checks to the `upToDate` methods, and adds a test for it on the `Project` resource.

I can't for the life of me work out how to add a suitable test within the existing framework for the `Group` resource - regardless of what I set, the test always passes when it should fail without the fixes to the `upToDate` method. Any ideas @janwillies ?

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Additional test added for Project. Group change is untested but identical.


[contribution process]: https://git.io/fj2m9
