### PR TITLE
write deploy token to kubernetes secret

### DIFF
--- a/pkg/controller/projects/deploytokens/controller.go
+++ b/pkg/controller/projects/deploytokens/controller.go
@@ -141,8 +141,11 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreateFailed)
 	}
 
+	connectionDetails := managed.ConnectionDetails{}
+	connectionDetails["token"] = []byte(dt.Token)
+
 	meta.SetExternalName(cr, strconv.Itoa(dt.ID))
-	return managed.ExternalCreation{ExternalNameAssigned: true}, nil
+	return managed.ExternalCreation{ExternalNameAssigned: true, ConnectionDetails: connectionDetails}, nil
 }
 
 func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {

--- a/pkg/controller/projects/deploytokens/controller_test.go
+++ b/pkg/controller/projects/deploytokens/controller_test.go
@@ -336,7 +336,10 @@ func TestCreate(t *testing.T) {
 						ProjectID: &deployTokenID,
 					}),
 				),
-				result: managed.ExternalCreation{ExternalNameAssigned: true},
+				result: managed.ExternalCreation{
+					ExternalNameAssigned: true,
+					ConnectionDetails:    managed.ConnectionDetails{"token": []byte("Token")},
+				},
 			},
 		},
 		"FailedCreation": {


### PR DESCRIPTION
Signed-off-by: Jan Willies <jan.willies@accenture.com>

### Description of your changes

The actual deploy token from gitlab needs to be returned in order for crossplane to write it to a secret. This was missing with #51  when taking over from #21 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
manual
