### PR TITLE
remove plaintext runner token from observation

### DIFF
--- a/apis/groups/v1alpha1/group_types.go
+++ b/apis/groups/v1alpha1/group_types.go
@@ -216,7 +216,6 @@ type GroupObservation struct {
 	FullPath            string             `json:"fullPath,omitempty"`
 	Statistics          *StorageStatistics `json:"statistics,omitempty"`
 	CustomAttributes    []CustomAttribute  `json:"customAttributes,omitempty"`
-	RunnersToken        string             `json:"runnersToken,omitempty"`
 	SharedWithGroups    []SharedWithGroups `json:"sharedWithGroups,omitempty"`
 	LDAPCN              string             `json:"ldapCn,omitempty"`
 	LDAPAccess          AccessLevelValue   `json:"ldapAccess,omitempty"`

--- a/apis/projects/v1alpha1/project_types.go
+++ b/apis/projects/v1alpha1/project_types.go
@@ -530,7 +530,6 @@ type ProjectObservation struct {
 	Permissions               *Permissions               `json:"permissions,omitempty"`
 	Public                    bool                       `json:"public,omitempty"`
 	ReadmeURL                 string                     `json:"readmeUrl,omitempty"`
-	RunnersToken              string                     `json:"runnersToken,omitempty"`
 	SSHURLToRepo              string                     `json:"sshUrlToRepo,omitempty"`
 	ServiceDeskAddress        string                     `json:"serviceDeskAddress,omitempty"`
 	SharedWithGroups          []SharedWithGroups         `json:"sharedWithGroups,omitempty"`

--- a/package/crds/groups.gitlab.crossplane.io_groups.yaml
+++ b/package/crds/groups.gitlab.crossplane.io_groups.yaml
@@ -224,8 +224,6 @@ spec:
                   markedForDeletionOn:
                     format: date-time
                     type: string
-                  runnersToken:
-                    type: string
                   sharedWithGroups:
                     items:
                       description: SharedWithGroups represents a GitLab Shared with groups.

--- a/package/crds/projects.gitlab.crossplane.io_projects.yaml
+++ b/package/crds/projects.gitlab.crossplane.io_projects.yaml
@@ -627,8 +627,6 @@ spec:
                     type: boolean
                   readmeUrl:
                     type: string
-                  runnersToken:
-                    type: string
                   serviceDeskAddress:
                     type: string
                   sharedWithGroups:

--- a/pkg/clients/groups/group.go
+++ b/pkg/clients/groups/group.go
@@ -75,13 +75,12 @@ func GenerateObservation(grp *gitlab.Group) v1alpha1.GroupObservation { // nolin
 		return v1alpha1.GroupObservation{}
 	}
 	group := v1alpha1.GroupObservation{
-		ID:           grp.ID,
-		AvatarURL:    grp.AvatarURL,
-		WebURL:       grp.WebURL,
-		FullName:     grp.FullName,
-		FullPath:     grp.FullPath,
-		RunnersToken: grp.RunnersToken,
-		LDAPCN:       grp.LDAPCN,
+		ID:        grp.ID,
+		AvatarURL: grp.AvatarURL,
+		WebURL:    grp.WebURL,
+		FullName:  grp.FullName,
+		FullPath:  grp.FullPath,
+		LDAPCN:    grp.LDAPCN,
 	}
 
 	if grp.CreatedAt != nil {

--- a/pkg/clients/projects/project.go
+++ b/pkg/clients/projects/project.go
@@ -81,7 +81,6 @@ func GenerateObservation(prj *gitlab.Project) v1alpha1.ProjectObservation { // n
 		Archived:             prj.Archived,
 		ForksCount:           prj.ForksCount,
 		StarCount:            prj.StarCount,
-		RunnersToken:         prj.RunnersToken,
 		EmptyRepo:            prj.EmptyRepo,
 		AvatarURL:            prj.AvatarURL,
 		LicenseURL:           prj.LicenseURL,

--- a/pkg/controller/groups/group_test.go
+++ b/pkg/controller/groups/group_test.go
@@ -277,7 +277,7 @@ func TestObserve(t *testing.T) {
 					withConditions(xpv1.Available()),
 					withPath(path),
 					withAnnotations(extNameAnnotation),
-					withStatus(v1alpha1.GroupObservation{RunnersToken: "token"}),
+					withStatus(v1alpha1.GroupObservation{}),
 				),
 				result: managed.ExternalObservation{
 					ResourceExists:          true,

--- a/pkg/controller/projects/project_test.go
+++ b/pkg/controller/projects/project_test.go
@@ -282,7 +282,7 @@ func TestObserve(t *testing.T) {
 					withConditions(xpv1.Available()),
 					withPath(&path),
 					withExternalName(extName),
-					withStatus(v1alpha1.ProjectObservation{RunnersToken: "token"}),
+					withStatus(v1alpha1.ProjectObservation{}),
 				),
 				result: managed.ExternalObservation{
 					ResourceExists:          true,


### PR DESCRIPTION
Signed-off-by: Benedikt Bock <benedikt.bock-extern@deutschebahn.com>
(external expert on behalf of DB Netz AG)

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #54: Removed plain text `runnersToken` from the observation objects of group and project MR

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tests and examples
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
