### PR TITLE
fix(e2e): change while loop that waits for deletion

### DIFF
--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -187,17 +187,10 @@ echo_step "uninstalling ${PROJECT_NAME}"
 
 echo "${INSTALL_YAML}" | "${KUBECTL}" delete -f -
 
-# check pods deleted
-timeout=60
-current=0
-step=3
-while [[ $(kubectl get providerrevision.pkg.crossplane.io -o name | wc -l) != "0" ]]; do
-  echo "waiting for provider to be deleted for another $step seconds"
-  current=$current+$step
-  if ! [[ $timeout > $current ]]; then
-    echo_error "timeout of ${timeout}s has been reached"
-  fi
-  sleep $step;
-done
+# wait for pods to be deleted
+echo "waiting for provider to be deleted (times out after 60 seconds)"
+if ! kubectl wait providerrevision.pkg.crossplane.io --for=delete --all --timeout=60s ; then
+  echo_error "Waiting for deletion of providers failed"
+fi
 
 echo_success "Integration tests succeeded!"


### PR DESCRIPTION
Changed the condition for the while loop that waits for the number of `providerrevision.pkg.crossplane.io` to reach 0 to complete the test.

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Changed the expression in the condition of the while loop that waits for the deletion of the provider to complete.
Instead of waiting for the result to be a literal string with the value `"0"`, it will first convert it to an integer. The conversion to an integer will strip away any white spaces. On MacOS X, the command returns the correct value but it has leading white spaces which causes the loop to become infinite. Converting it to an integer first gets around this issue.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #71 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
I've run `make e2e`.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
