### PR TITLE
fix: project var overwites despite distinct env scope

### DIFF
--- a/pkg/clients/projects/variable.go
+++ b/pkg/clients/projects/variable.go
@@ -121,9 +121,43 @@ func GenerateUpdateVariableOptions(p *v1alpha1.VariableParameters) *gitlab.Updat
 		Masked:           p.Masked,
 		EnvironmentScope: p.EnvironmentScope,
 		Raw:              p.Raw,
+		Filter:           GenerateVariableFilter(p),
 	}
 
 	return variable
+}
+
+// GenerateGetVariableOptions generates project get options
+func GenerateGetVariableOptions(p *v1alpha1.VariableParameters) *gitlab.GetProjectVariableOptions {
+	if p.EnvironmentScope == nil {
+		return nil
+	}
+
+	return &gitlab.GetProjectVariableOptions{
+		Filter: GenerateVariableFilter(p),
+	}
+}
+
+// GenerateRemoveVariableOptions generates project remove options.
+func GenerateRemoveVariableOptions(p *v1alpha1.VariableParameters) *gitlab.RemoveProjectVariableOptions {
+	if p.EnvironmentScope == nil {
+		return nil
+	}
+
+	return &gitlab.RemoveProjectVariableOptions{
+		Filter: GenerateVariableFilter(p),
+	}
+}
+
+// GenerateVariableFilter generates a variable filter that matches the variable parameters' environment scope.
+func GenerateVariableFilter(p *v1alpha1.VariableParameters) *gitlab.VariableFilter {
+	if p.EnvironmentScope == nil {
+		return nil
+	}
+
+	return &gitlab.VariableFilter{
+		EnvironmentScope: *p.EnvironmentScope,
+	}
 }
 
 // IsVariableUpToDate checks whether there is a change in any of the modifiable fields.

--- a/pkg/clients/projects/variable_test.go
+++ b/pkg/clients/projects/variable_test.go
@@ -195,6 +195,7 @@ func TestGenerateUpdateVariableOptions(t *testing.T) {
 				Masked:           &variableMasked,
 				EnvironmentScope: &variableEnvScope,
 				Raw:              &variableRaw,
+				Filter:           &gitlab.VariableFilter{EnvironmentScope: variableEnvScope},
 			},
 		},
 	}
@@ -274,4 +275,78 @@ func TestIsVariableUpToDate(t *testing.T) {
 		})
 	}
 
+}
+
+func TestGenerateGetVariableOptions(t *testing.T) {
+	type args struct {
+		p *v1alpha1.VariableParameters
+	}
+	tests := map[string]struct {
+		args args
+		want *gitlab.GetProjectVariableOptions
+	}{
+		"Scope": {
+			args: args{
+				p: &v1alpha1.VariableParameters{
+					EnvironmentScope: &variableEnvScope,
+				},
+			},
+			want: &gitlab.GetProjectVariableOptions{
+				Filter: &gitlab.VariableFilter{
+					EnvironmentScope: variableEnvScope,
+				},
+			},
+		},
+		"NoScope": {
+			args: args{
+				p: &v1alpha1.VariableParameters{},
+			},
+			want: nil,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := GenerateGetVariableOptions(tc.args.p)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("r: -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGenerateRemoveVariableOptions(t *testing.T) {
+	type args struct {
+		p *v1alpha1.VariableParameters
+	}
+	tests := map[string]struct {
+		args args
+		want *gitlab.RemoveProjectVariableOptions
+	}{
+		"Scope": {
+			args: args{
+				p: &v1alpha1.VariableParameters{
+					EnvironmentScope: &variableEnvScope,
+				},
+			},
+			want: &gitlab.RemoveProjectVariableOptions{
+				Filter: &gitlab.VariableFilter{
+					EnvironmentScope: variableEnvScope,
+				},
+			},
+		},
+		"NoScope": {
+			args: args{
+				p: &v1alpha1.VariableParameters{},
+			},
+			want: nil,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := GenerateRemoveVariableOptions(tc.args.p)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("r: -want, +got:\n%s", diff)
+			}
+		})
+	}
 }

--- a/pkg/controller/projects/variables/controller.go
+++ b/pkg/controller/projects/variables/controller.go
@@ -90,7 +90,7 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	if !ok {
 		return managed.ExternalObservation{}, errors.New(errNotVariable)
 	}
-	variable, _, err := e.client.GetVariable(*cr.Spec.ForProvider.ProjectID, cr.Spec.ForProvider.Key, nil)
+	variable, _, err := e.client.GetVariable(*cr.Spec.ForProvider.ProjectID, cr.Spec.ForProvider.Key, projects.GenerateGetVariableOptions(&cr.Spec.ForProvider), gitlab.WithContext(ctx))
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(resource.Ignore(projects.IsErrorVariableNotFound, err), errGetFailed)
 	}
@@ -168,7 +168,7 @@ func (e *external) Delete(ctx context.Context, mg resource.Managed) error {
 	_, err := e.client.RemoveVariable(
 		*cr.Spec.ForProvider.ProjectID,
 		cr.Spec.ForProvider.Key,
-		nil,
+		projects.GenerateRemoveVariableOptions(&cr.Spec.ForProvider),
 		gitlab.WithContext(ctx),
 	)
 	return errors.Wrap(err, errDeleteFailed)


### PR DESCRIPTION
When creating, updating or deleting variables, variables with identical key names were overwritten despite having distinct environment scopes.

* Added function that will generate a variable filter struct and added it where needed.
* Added functions that generate variable options for get and remove operations.

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #70

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
* Tested in my local cluster. Creating, updating and deleting doesn't affect other variables.
* Ran `make e2e`.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
