### PR TITLE
fix(projects): Avoid setting MirrorUserID in lateInitialize() if atProvider value is 0 (default value)

### DIFF
--- a/pkg/controller/projects/project.go
+++ b/pkg/controller/projects/project.go
@@ -216,7 +216,7 @@ func lateInitialize(in *v1alpha1.ProjectParameters, project *gitlab.Project) { /
 	if in.MirrorTriggerBuilds == nil {
 		in.MirrorTriggerBuilds = &project.MirrorTriggerBuilds
 	}
-	if in.MirrorUserID == nil {
+	if in.MirrorUserID == nil && project.MirrorUserID != 0 { // since project.MirrorUserID is non-nullable, value `0` treated as `not set`
 		in.MirrorUserID = &project.MirrorUserID
 	}
 	if in.OnlyAllowMergeIfAllDiscussionsAreResolved == nil {


### PR DESCRIPTION
Fixes #74 

For already created resources it will require to remove "MirrorUserID" value from managed resource.

### How has this code been tested

Unit Test
