### PR TITLE
fix: Add 404 response status ignore in Observe

### DIFF
--- a/pkg/clients/groups/deploytoken.go
+++ b/pkg/clients/groups/deploytoken.go
@@ -27,7 +27,7 @@ import (
 
 // DeployTokenClient defines Gitlab Group service operations
 type DeployTokenClient interface {
-	ListGroupDeployTokens(gid interface{}, opt *gitlab.ListGroupDeployTokensOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.DeployToken, *gitlab.Response, error)
+	GetGroupDeployToken(gid interface{}, deployToken int, options ...gitlab.RequestOptionFunc) (*gitlab.DeployToken, *gitlab.Response, error)
 	CreateGroupDeployToken(gid interface{}, opt *gitlab.CreateGroupDeployTokenOptions, options ...gitlab.RequestOptionFunc) (*gitlab.DeployToken, *gitlab.Response, error)
 	DeleteGroupDeployToken(gid interface{}, deployToken int, options ...gitlab.RequestOptionFunc) (*gitlab.Response, error)
 }

--- a/pkg/clients/groups/fake/fake.go
+++ b/pkg/clients/groups/fake/fake.go
@@ -40,9 +40,9 @@ type MockClient struct {
 	MockEditMember   func(gid interface{}, user int, opt *gitlab.EditGroupMemberOptions, options ...gitlab.RequestOptionFunc) (*gitlab.GroupMember, *gitlab.Response, error)
 	MockRemoveMember func(gid interface{}, user int, options ...gitlab.RequestOptionFunc) (*gitlab.Response, error)
 
-	MockListDeployTokens  func(gid interface{}, opt *gitlab.ListGroupDeployTokensOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.DeployToken, *gitlab.Response, error)
-	MockCreateDeployToken func(gid interface{}, opt *gitlab.CreateGroupDeployTokenOptions, options ...gitlab.RequestOptionFunc) (*gitlab.DeployToken, *gitlab.Response, error)
-	MockDeleteDeployToken func(gid interface{}, deployToken int, options ...gitlab.RequestOptionFunc) (*gitlab.Response, error)
+	MockGetGroupDeployToken    func(gid interface{}, deployToken int, options ...gitlab.RequestOptionFunc) (*gitlab.DeployToken, *gitlab.Response, error)
+	MockCreateGroupDeployToken func(gid interface{}, opt *gitlab.CreateGroupDeployTokenOptions, options ...gitlab.RequestOptionFunc) (*gitlab.DeployToken, *gitlab.Response, error)
+	MockDeleteGroupDeployToken func(gid interface{}, deployToken int, options ...gitlab.RequestOptionFunc) (*gitlab.Response, error)
 }
 
 // GetGroup calls the underlying MockGetGroup method.
@@ -95,17 +95,17 @@ func (c *MockClient) RemoveGroupMember(gid interface{}, user int, opt *gitlab.Re
 	return c.MockRemoveMember(gid, user)
 }
 
-// ListGroupDeployTokens calls the underlying MockListGroupDeployTokens method.
-func (c *MockClient) ListGroupDeployTokens(gid interface{}, opt *gitlab.ListGroupDeployTokensOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.DeployToken, *gitlab.Response, error) {
-	return c.MockListDeployTokens(gid, opt)
+// GetGroupDeployToken calls the underlying MockGetGroupDeployToken method.
+func (c *MockClient) GetGroupDeployToken(gid interface{}, deployToken int, options ...gitlab.RequestOptionFunc) (*gitlab.DeployToken, *gitlab.Response, error) {
+	return c.MockGetGroupDeployToken(gid, deployToken)
 }
 
 // CreateGroupDeployToken calls the underlying MockCreateGroupDeployToken method.
 func (c *MockClient) CreateGroupDeployToken(gid interface{}, opt *gitlab.CreateGroupDeployTokenOptions, options ...gitlab.RequestOptionFunc) (*gitlab.DeployToken, *gitlab.Response, error) {
-	return c.MockCreateDeployToken(gid, opt)
+	return c.MockCreateGroupDeployToken(gid, opt)
 }
 
 // DeleteGroupDeployToken calls the underlying MockDeleteGroupDeployToken method.
 func (c *MockClient) DeleteGroupDeployToken(gid interface{}, deployToken int, options ...gitlab.RequestOptionFunc) (*gitlab.Response, error) {
-	return c.MockDeleteDeployToken(gid, deployToken)
+	return c.MockDeleteGroupDeployToken(gid, deployToken)
 }

--- a/pkg/clients/projects/fake/fake.go
+++ b/pkg/clients/projects/fake/fake.go
@@ -53,9 +53,9 @@ type MockClient struct {
 	MockListVariables  func(pid interface{}, opt *gitlab.ListProjectVariablesOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.ProjectVariable, *gitlab.Response, error)
 	MockRemoveVariable func(pid interface{}, key string, opt *gitlab.RemoveProjectVariableOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Response, error)
 
-	MockGetAccessTokens   func(pid interface{}, id int, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectAccessToken, *gitlab.Response, error)
-	MockCreateAccessToken func(pid interface{}, opt *gitlab.CreateProjectAccessTokenOptions, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectAccessToken, *gitlab.Response, error)
-	MockRevokeAccessToken func(pid interface{}, id int, options ...gitlab.RequestOptionFunc) (*gitlab.Response, error)
+	MockGetProjectAccessToken    func(pid interface{}, id int, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectAccessToken, *gitlab.Response, error)
+	MockCreateProjectAccessToken func(pid interface{}, opt *gitlab.CreateProjectAccessTokenOptions, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectAccessToken, *gitlab.Response, error)
+	MockRevokeProjectAccessToken func(pid interface{}, id int, options ...gitlab.RequestOptionFunc) (*gitlab.Response, error)
 
 	MockAddDeployKey    func(pid interface{}, opt *gitlab.AddDeployKeyOptions, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectDeployKey, *gitlab.Response, error)
 	MockDeleteDeployKey func(pid interface{}, deployKey int, options ...gitlab.RequestOptionFunc) (*gitlab.Response, error)
@@ -231,17 +231,17 @@ func (c *MockClient) UpdateDeployKey(pid interface{}, deployKey int, opt *gitlab
 	return c.MockUpdateDeployKey(pid, deployKey, opt)
 }
 
-// GetProjectAccessToken calls the underlying MockGetAccessTokens method.
+// GetProjectAccessToken calls the underlying MockGetProjectAccessToken method.
 func (c *MockClient) GetProjectAccessToken(pid interface{}, id int, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectAccessToken, *gitlab.Response, error) {
-	return c.MockGetAccessTokens(pid, id)
+	return c.MockGetProjectAccessToken(pid, id)
 }
 
 // CreateProjectAccessToken calls the underlying MockCreateProjectAccessToken method.
 func (c *MockClient) CreateProjectAccessToken(pid interface{}, opt *gitlab.CreateProjectAccessTokenOptions, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectAccessToken, *gitlab.Response, error) {
-	return c.MockCreateAccessToken(pid, opt)
+	return c.MockCreateProjectAccessToken(pid, opt)
 }
 
-// RevokeProjectAccessToken calls the underlying MockDeleteProjectAccessToken method.
+// RevokeProjectAccessToken calls the underlying MockRevokeProjectAccessToken method.
 func (c *MockClient) RevokeProjectAccessToken(pid interface{}, id int, options ...gitlab.RequestOptionFunc) (*gitlab.Response, error) {
-	return c.MockRevokeAccessToken(pid, id)
+	return c.MockRevokeProjectAccessToken(pid, id)
 }

--- a/pkg/controller/groups/group.go
+++ b/pkg/controller/groups/group.go
@@ -103,12 +103,15 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 
 	groupID, err := strconv.Atoi(externalName)
 	if err != nil {
-		return managed.ExternalObservation{}, errors.New(errNotGroup)
+		return managed.ExternalObservation{}, errors.New(errIDNotInt)
 	}
 
-	grp, _, err := e.client.GetGroup(groupID, nil)
+	grp, res, err := e.client.GetGroup(groupID, nil)
 	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(resource.Ignore(groups.IsErrorGroupNotFound, err), errGetFailed)
+		if clients.IsResponseNotFound(res) {
+			return managed.ExternalObservation{}, nil
+		}
+		return managed.ExternalObservation{}, errors.Wrap(err, errGetFailed)
 	}
 
 	current := cr.Spec.ForProvider.DeepCopy()

--- a/pkg/controller/projects/accesstokens/controller.go
+++ b/pkg/controller/projects/accesstokens/controller.go
@@ -109,8 +109,11 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.New(errMissingProjectID)
 	}
 
-	at, _, err := e.client.GetProjectAccessToken(*cr.Spec.ForProvider.ProjectID, accessTokenID)
+	at, res, err := e.client.GetProjectAccessToken(*cr.Spec.ForProvider.ProjectID, accessTokenID)
 	if err != nil {
+		if clients.IsResponseNotFound(res) {
+			return managed.ExternalObservation{}, nil
+		}
 		return managed.ExternalObservation{}, errors.Wrap(err, errAccessTokentNotFound)
 	}
 

--- a/pkg/controller/projects/deploykeys/controller_test.go
+++ b/pkg/controller/projects/deploykeys/controller_test.go
@@ -18,6 +18,7 @@ package deploykeys
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"testing"
 	"time"
@@ -168,7 +169,7 @@ func TestObserve(t *testing.T) {
 				cr: buildDeployKey(withExternalName(testExternalName)),
 				deployKeyService: &fake.MockClient{
 					MockGetDeployKey: func(pid interface{}, deployKey int, options ...*gitlab.RequestOptionFunc) (*gitlab.ProjectDeployKey, *gitlab.Response, error) {
-						return nil, &gitlab.Response{}, errors.New(testGetKeyErrorMessage)
+						return nil, &gitlab.Response{Response: &http.Response{StatusCode: 400}}, errors.New(testGetKeyErrorMessage)
 					},
 				},
 			},
@@ -178,12 +179,12 @@ func TestObserve(t *testing.T) {
 				result: managed.ExternalObservation{},
 			},
 		},
-		"GetKeyNotFound": {
+		"GetErr404": {
 			args: args{
 				cr: buildDeployKey(withExternalName(testExternalName)),
 				deployKeyService: &fake.MockClient{
 					MockGetDeployKey: func(pid interface{}, deployKey int, options ...*gitlab.RequestOptionFunc) (*gitlab.ProjectDeployKey, *gitlab.Response, error) {
-						return nil, nil, nil
+						return nil, &gitlab.Response{Response: &http.Response{StatusCode: 404}}, errors.New("")
 					},
 				},
 			},

--- a/pkg/controller/projects/deploytokens/controller.go
+++ b/pkg/controller/projects/deploytokens/controller.go
@@ -106,14 +106,13 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.New(errProjectIDMissing)
 	}
 
-	dt, _, err := e.client.GetProjectDeployToken(*cr.Spec.ForProvider.ProjectID, id)
+	dt, res, err := e.client.GetProjectDeployToken(*cr.Spec.ForProvider.ProjectID, id)
 
 	if err != nil {
+		if clients.IsResponseNotFound(res) {
+			return managed.ExternalObservation{}, nil
+		}
 		return managed.ExternalObservation{}, errors.Wrap(err, errGetFailed)
-	}
-
-	if dt == nil {
-		return managed.ExternalObservation{}, nil
 	}
 
 	current := cr.Spec.ForProvider.DeepCopy()

--- a/pkg/controller/projects/deploytokens/controller_test.go
+++ b/pkg/controller/projects/deploytokens/controller_test.go
@@ -19,6 +19,7 @@ package deploytokens
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strconv"
 	"testing"
 	"time"
@@ -160,11 +161,11 @@ func TestObserve(t *testing.T) {
 				err: errors.Wrap(errBoom, errGetFailed),
 			},
 		},
-		"DeployTokenNotFound": {
+		"ErrGet404": {
 			args: args{
 				deployToken: &fake.MockClient{
 					MockGetProjectDeployToken: func(pid interface{}, deployToken int, options ...gitlab.RequestOptionFunc) (*gitlab.DeployToken, *gitlab.Response, error) {
-						return nil, &gitlab.Response{}, nil
+						return nil, &gitlab.Response{Response: &http.Response{StatusCode: 404}}, errBoom
 					},
 				},
 				cr: deployToken(
@@ -190,6 +191,7 @@ func TestObserve(t *testing.T) {
 					ResourceUpToDate:        false,
 					ResourceLateInitialized: false,
 				},
+				err: nil,
 			},
 		},
 		"LateInitSuccess": {

--- a/pkg/controller/projects/hooks/controller.go
+++ b/pkg/controller/projects/hooks/controller.go
@@ -102,8 +102,11 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.New(errNotHook)
 	}
 
-	projecthook, _, err := e.client.GetProjectHook(*cr.Spec.ForProvider.ProjectID, hookid)
+	projecthook, res, err := e.client.GetProjectHook(*cr.Spec.ForProvider.ProjectID, hookid)
 	if err != nil {
+		if clients.IsResponseNotFound(res) {
+			return managed.ExternalObservation{}, nil
+		}
 		return managed.ExternalObservation{}, errors.Wrap(resource.Ignore(projects.IsErrorHookNotFound, err), errGetFailed)
 	}
 

--- a/pkg/controller/projects/hooks/controller_test.go
+++ b/pkg/controller/projects/hooks/controller_test.go
@@ -19,6 +19,7 @@ package hooks
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
@@ -198,6 +199,27 @@ func TestObserve(t *testing.T) {
 					ResourceUpToDate:        true,
 					ResourceLateInitialized: true,
 				},
+			},
+		},
+		"ErrGet404": {
+			args: args{
+				projecthook: &fake.MockClient{
+					MockGetHook: func(pid interface{}, hook int, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectHook, *gitlab.Response, error) {
+						return nil, &gitlab.Response{Response: &http.Response{StatusCode: 404}}, errBoom
+					},
+				},
+				cr: projecthook(
+					withProjectID(projectID),
+					withExternalName(projectHookID),
+				),
+			},
+			want: want{
+				cr: projecthook(
+					withProjectID(projectID),
+					withExternalName(projectHookID),
+				),
+				result: managed.ExternalObservation{},
+				err:    nil,
 			},
 		},
 	}

--- a/pkg/controller/projects/project_test.go
+++ b/pkg/controller/projects/project_test.go
@@ -18,6 +18,7 @@ package projects
 
 import (
 	"context"
+	"net/http"
 	"reflect"
 	"strconv"
 	"testing"
@@ -224,7 +225,22 @@ func TestObserve(t *testing.T) {
 			args: args{
 				project: &fake.MockClient{
 					MockGetProject: func(pid interface{}, opt *gitlab.GetProjectOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Project, *gitlab.Response, error) {
-						return nil, &gitlab.Response{}, errBoom
+						return nil, &gitlab.Response{Response: &http.Response{StatusCode: 400}}, errBoom
+					},
+				},
+				cr: project(withExternalName(extName)),
+			},
+			want: want{
+				cr:     project(withExternalName(extName)),
+				result: managed.ExternalObservation{ResourceExists: false},
+				err:    errors.Wrap(errBoom, errGetFailed),
+			},
+		},
+		"ErrGet404": {
+			args: args{
+				project: &fake.MockClient{
+					MockGetProject: func(pid interface{}, opt *gitlab.GetProjectOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Project, *gitlab.Response, error) {
+						return nil, &gitlab.Response{Response: &http.Response{StatusCode: 404}}, errBoom
 					},
 				},
 				cr: project(withExternalName(extName)),


### PR DESCRIPTION
Fixes #85 

groups.deploytoken.Observe: 
 - switch from `ListGroupDeployTokens` to `GetGroupDeployToken`
 - add `GroupID` nil check
 - add `err` nil check
 - add `response status` 404 check on `get`
 
groups.group.Observe:
 - add `response status` 404 check on `get`
 
groups.member.Observe:
 - add `response status` 404 check on `get`

projects.accesstoken.Observe:
 - add `response status` 404 check on `get`

projects.deploykey.Observe:
 - add `response status` 404 check on `get`
 - remove returned resource nil check
 
projects.deploytoken.Observe:
 - add `response status` 404 check on `get`
 - remove returned resource nil check

projects.hook.Observe:
 - add `response status` 404 check on `get`

projects.member.Observe:
 - add `response status` 404 check on `get`
 - remove returned resource nil check

projects.project.Observe:
 - add `response status` 404 check on `get`
 - remove returned resource nil check

projects.variable.Observe:
 - add `response status` 404 check on `get`