### PR TITLE
fix(group): add nil check before ParentID dereferencing in ResolveReferences()

### DIFF
--- a/apis/groups/v1alpha1/referencers.go
+++ b/apis/groups/v1alpha1/referencers.go
@@ -100,10 +100,14 @@ func (mg *Group) ResolveReferences(ctx context.Context, c client.Reader) error {
 	var rsp reference.ResolutionResponse
 	var err error
 
-	idstr := strconv.Itoa(*mg.Spec.ForProvider.ParentID)
+	var idstrp *string
+	if mg.Spec.ForProvider.ParentID != nil {
+		str := strconv.Itoa(*mg.Spec.ForProvider.ParentID)
+		idstrp = &str
+	}
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
-		CurrentValue: reference.FromPtrValue(&idstr),
+		CurrentValue: reference.FromPtrValue(idstrp),
 		Extract:      reference.ExternalName(),
 		Reference:    mg.Spec.ForProvider.ParentIDRef,
 		Selector:     mg.Spec.ForProvider.ParentIDSelector,
@@ -125,7 +129,7 @@ func (mg *Group) ResolveReferences(ctx context.Context, c client.Reader) error {
 	mg.Spec.ForProvider.ParentIDRef = rsp.ResolvedReference
 
 	for i3 := 0; i3 < len(mg.Spec.ForProvider.SharedWithGroups); i3++ {
-		idstr = strconv.Itoa(*mg.Spec.ForProvider.SharedWithGroups[i3].GroupID)
+		idstr := strconv.Itoa(*mg.Spec.ForProvider.SharedWithGroups[i3].GroupID)
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(&idstr),
 			Extract:      reference.ExternalName(),


### PR DESCRIPTION
### Description of your changes
add nil check for `ParentID` in ResolveReferences() for group. 

I have:
- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

