### PR TITLE
fix(ci): update build submodule and remove deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 10m
+  timeout: 10m
 
   skip-files:
   - "zz_generated\\..+\\.go$"
@@ -23,13 +23,16 @@ linters-settings:
     # see https://github.com/kisielk/errcheck#the-deprecated-method for details
     ignore: fmt:.*,io/ioutil:^Read.*
 
+  revive:
+    # minimal confidence for issues, default is 0.8
+    confidence: 0.8
+    rules:
+      - name: package-comments
+        disabled: true
+
   govet:
     # report about shadowed variables
     check-shadowing: false
-
-  golint:
-    # minimal confidence for issues, default is 0.8
-    min-confidence: 0.8
 
   gofmt:
     # simplify code: gofmt with `-s` option, true by default
@@ -67,7 +70,7 @@ linters-settings:
     # XXX: if you enable this setting, unused will report a lot of false-positives in text editors:
     # if it's called for subdir of a project it can't find funcs usages. All text editor integrations
     # with golangci-lint call it on a directory with the changed file.
-    check-exported: false
+    exported-is-used: false
 
   unparam:
     # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
@@ -108,12 +111,11 @@ linters:
     - govet
     - gocyclo
     - gocritic
-    - interfacer
     - goconst
     - goimports
     - gofmt  # We enable this as well as goimports for its simplify mode.
     - prealloc
-    - golint
+    - revive
     - unconvert
     - misspell
     - nakedret
@@ -189,7 +191,7 @@ issues:
   new: false
 
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
-  max-per-linter: 0
+  max-issues-per-linter: 0
 
   # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0


### PR DESCRIPTION
### Description of your changes

* Updated submodule `build` to `75a9fe3ae6b6de82c5f7ddc6a267617940f16b83` (refs/heads/master) .
* Removed linter `interfacer` (deprecated, archived, last commit was 6 years ago).
* Replaced linter `golint` (deprecated) with the recommended replacement `revive`.
* Updated `.golangci.yml` to reflect the changes above and replaced deprecated configurations with new key names.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

It only affects the `reviewable` target in the Makefile, so `make reviewable test` as indicated in the PR template is more than enough.

[contribution process]: https://git.io/fj2m9
