### PR TITLE
fix(groups): SharedWithGroupsObservation fields no longer required

### DIFF
--- a/apis/groups/v1alpha1/group_types.go
+++ b/apis/groups/v1alpha1/group_types.go
@@ -246,11 +246,11 @@ type GroupObservation struct {
 
 // SharedWithGroupsObservation is the observed state of a SharedWithGroups.
 type SharedWithGroupsObservation struct {
-	GroupID          *int         `json:"groupId"`
-	GroupName        *string      `json:"groupName"`
-	GroupFullPath    *string      `json:"groupFullPath"`
-	GroupAccessLevel *int         `json:"groupAccessLevel"`
-	ExpiresAt        *metav1.Time `json:"expiresAt"`
+	GroupID          *int         `json:"groupId,omitempty"`
+	GroupName        *string      `json:"groupName,omitempty"`
+	GroupFullPath    *string      `json:"groupFullPath,omitempty"`
+	GroupAccessLevel *int         `json:"groupAccessLevel,omitempty"`
+	ExpiresAt        *metav1.Time `json:"expiresAt,omitempty"`
 }
 
 // A GroupSpec defines the desired state of a Gitlab Group.

--- a/package/crds/groups.gitlab.crossplane.io_groups.yaml
+++ b/package/crds/groups.gitlab.crossplane.io_groups.yaml
@@ -552,12 +552,6 @@ spec:
                           type: integer
                         groupName:
                           type: string
-                      required:
-                      - expiresAt
-                      - groupAccessLevel
-                      - groupFullPath
-                      - groupId
-                      - groupName
                       type: object
                     type: array
                   statistics:


### PR DESCRIPTION
### Description of your changes

`SharedWithGroupsObservation` childs are no longer required.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
na
