### PR TITLE
fix missing logger

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -60,6 +61,8 @@ func main() {
 
 	zl := zap.New(zap.UseDevMode(*debug), UseISO8601())
 	log := logging.NewLogrLogger(zl.WithName("provider-gitlab"))
+	// explicitly  provide a no-op logger by default, otherwise controller-runtime gives a warning
+	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 	if *debug {
 		// The controller-runtime runs with a no-op logger by default. It is
 		// *very* verbose even at info level, so we only provide it a real


### PR DESCRIPTION
### Description of your changes
Add a default no-op logger so that the controller-runtime isn't producing a stack trace.
Other providers are already using the same solution to avoid this problem:
- provider-kubernetes: https://github.com/crossplane-contrib/provider-kubernetes/blob/main/cmd/provider/main.go#L74-L75
- provider-helm: https://github.com/crossplane-contrib/provider-helm/blob/master/cmd/provider/main.go#L64-L65


Fixes #150 

I have:
- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Manually built & run test suite.

[contribution process]: https://git.io/fj2m9
