### PR TITLE
feat(authentication): add support for all authentification types

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ spec:
   baseURL: https://gitlab.com/
   credentials:
     source: Secret
+    method: PersonalAccessToken
     secretRef:
       namespace: crossplane-system
       name: gitlab-credentials

--- a/apis/v1beta1/providerconfig_types.go
+++ b/apis/v1beta1/providerconfig_types.go
@@ -21,6 +21,23 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// BasicAuth is gitlab's BasicAuth method of authentification that needs a username and a password
+	BasicAuth AuthType = "BasicAuth"
+
+	// JobToken is gitlab's JobToken method of authentification
+	JobToken AuthType = "JobToken"
+
+	// OAuthToken is gitlab's OAuthToken method of authentification
+	OAuthToken AuthType = "OAuthToken"
+
+	// PersonalAccessToken is gitlab's PersonalAccessToken method of authentification.
+	PersonalAccessToken AuthType = "PersonalAccessToken"
+)
+
+// AuthType represents an authentication type within GitLab.
+type AuthType string
+
 // A ProviderConfigSpec defines the desired state of a ProviderConfig.
 type ProviderConfigSpec struct {
 	// Base URL of the Gitlab Service
@@ -39,6 +56,10 @@ type ProviderCredentials struct {
 	// Source of the provider credentials.
 	// +kubebuilder:validation:Enum=None;Secret;InjectedIdentity;Environment;Filesystem
 	Source xpv1.CredentialsSource `json:"source"`
+
+	// Method of authentification can be BasicAuth, JobToken, OAuthToken or PersonalAccessToken (default)
+	// +optional
+	Method AuthType `json:"method"`
 
 	xpv1.CommonCredentialSelectors `json:",inline"`
 }

--- a/examples/providerconfig/provider.yaml
+++ b/examples/providerconfig/provider.yaml
@@ -8,6 +8,7 @@ spec:
   baseURL: https://gitlab.com/
   credentials:
     source: Secret
+    method: PersonalAccessToken
     secretRef:
       namespace: crossplane-system
       name: gitlab-credentials

--- a/package/crds/gitlab.crossplane.io_providerconfigs.yaml
+++ b/package/crds/gitlab.crossplane.io_providerconfigs.yaml
@@ -80,6 +80,10 @@ spec:
                     required:
                     - path
                     type: object
+                  method:
+                    description: Method of authentification can be BasicAuth, JobToken,
+                      OAuthToken or PersonalAccessToken (default)
+                    type: string
                   secretRef:
                     description: |-
                       A SecretRef is a reference to a secret key that contains the credentials


### PR DESCRIPTION
### Description of your changes

Adding support of different authentification types supported by the gitlab SDK:
[BasicAuth](https://docs.gitlab.com/ee/user/application_security/dast/browser/checks/287.1.html) with username and password, [JobToken](https://docs.gitlab.com/ee/ci/jobs/ci_job_token.html), [OAuthToken](https://docs.gitlab.com/ee/api/oauth2.html), [PersonalAccessToken](https://docs.gitlab.com/ee/security/tokens/#personal-access-tokens) that stays the default for retro-compatiability in mind.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

This version is running in production.