### PR TITLE
Promote ManagementPolicies to beta

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -144,8 +144,8 @@ func main() {
 	}
 
 	if *enableManagementPolicies {
-		o.Features.Enable(features.EnableAlphaManagementPolicies)
-		log.Info("Alpha feature enabled", "flag", features.EnableAlphaManagementPolicies)
+		o.Features.Enable(feature.EnableBetaManagementPolicies)
+		log.Info("Beta feature enabled", "flag", feature.EnableBetaManagementPolicies)
 	}
 
 	kingpin.FatalIfError(controller.Setup(mgr, o), "Cannot setup Gitlab controllers")

--- a/pkg/controller/groups/accesstokens/controller.go
+++ b/pkg/controller/groups/accesstokens/controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/connection"
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/crossplane/crossplane-runtime/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -72,7 +73,7 @@ func SetupAccessToken(mgr ctrl.Manager, o controller.Options) error {
 		managed.WithConnectionPublishers(cps...),
 	}
 
-	if o.Features.Enabled(features.EnableAlphaManagementPolicies) {
+	if o.Features.Enabled(feature.EnableBetaManagementPolicies) {
 		reconcilerOpts = append(reconcilerOpts, managed.WithManagementPolicies())
 	}
 
@@ -168,7 +169,6 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		groups.GenerateCreateGroupAccessTokenOptions(cr.Name, &cr.Spec.ForProvider),
 		gitlab.WithContext(ctx),
 	)
-
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreateFailed)
 	}
@@ -193,7 +193,6 @@ func (e *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 
 	accessTokenID, err := strconv.Atoi(meta.GetExternalName(cr))
-
 	if err != nil {
 		return managed.ExternalDelete{}, errors.New(errExternalNameNotInt)
 	}

--- a/pkg/controller/groups/deploytokens/controller.go
+++ b/pkg/controller/groups/deploytokens/controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/connection"
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/crossplane/crossplane-runtime/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -69,7 +70,7 @@ func SetupDeployToken(mgr ctrl.Manager, o controller.Options) error {
 		managed.WithConnectionPublishers(cps...),
 	}
 
-	if o.Features.Enabled(features.EnableAlphaManagementPolicies) {
+	if o.Features.Enabled(feature.EnableBetaManagementPolicies) {
 		reconcilerOpts = append(reconcilerOpts, managed.WithManagementPolicies())
 	}
 
@@ -190,7 +191,6 @@ func (e *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 
 	deployTokenID, err := strconv.Atoi(meta.GetExternalName(cr))
-
 	if err != nil {
 		return managed.ExternalDelete{}, errors.New(errNotDeployToken)
 	}

--- a/pkg/controller/groups/groups/group.go
+++ b/pkg/controller/groups/groups/group.go
@@ -26,6 +26,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/connection"
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/crossplane/crossplane-runtime/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -76,7 +77,7 @@ func SetupGroup(mgr ctrl.Manager, o controller.Options) error {
 		managed.WithConnectionPublishers(cps...),
 	}
 
-	if o.Features.Enabled(features.EnableAlphaManagementPolicies) {
+	if o.Features.Enabled(feature.EnableBetaManagementPolicies) {
 		reconcilerOpts = append(reconcilerOpts, managed.WithManagementPolicies())
 	}
 

--- a/pkg/controller/groups/members/controller.go
+++ b/pkg/controller/groups/members/controller.go
@@ -20,6 +20,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/connection"
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/crossplane/crossplane-runtime/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/statemetrics"
@@ -62,7 +63,8 @@ func SetupMember(mgr ctrl.Manager, o controller.Options) error {
 		managed.WithExternalConnecter(&connector{
 			kube:              mgr.GetClient(),
 			newGitlabClientFn: groups.NewMemberClient,
-			newUserClientFn:   users.NewUserClient}),
+			newUserClientFn:   users.NewUserClient,
+		}),
 		managed.WithInitializers(),
 		managed.WithPollInterval(o.PollInterval),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
@@ -70,7 +72,7 @@ func SetupMember(mgr ctrl.Manager, o controller.Options) error {
 		managed.WithConnectionPublishers(cps...),
 	}
 
-	if o.Features.Enabled(features.EnableAlphaManagementPolicies) {
+	if o.Features.Enabled(feature.EnableBetaManagementPolicies) {
 		reconcilerOpts = append(reconcilerOpts, managed.WithManagementPolicies())
 	}
 
@@ -231,7 +233,6 @@ func (e *external) Disconnect(ctx context.Context) error {
 
 // isMemberUpToDate checks whether there is a change in any of the modifiable fields.
 func isMemberUpToDate(p *v1alpha1.MemberParameters, g *gitlab.GroupMember) bool {
-
 	if !cmp.Equal(int(p.AccessLevel), int(g.AccessLevel)) {
 		return false
 	}

--- a/pkg/controller/groups/samlgrouplinks/controller.go
+++ b/pkg/controller/groups/samlgrouplinks/controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/connection"
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/crossplane/crossplane-runtime/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -67,7 +68,7 @@ func SetupSamlGroupLink(mgr ctrl.Manager, o controller.Options) error {
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithConnectionPublishers(cps...),
 	}
-	if o.Features.Enabled(features.EnableAlphaManagementPolicies) {
+	if o.Features.Enabled(feature.EnableBetaManagementPolicies) {
 		reconcilerOpts = append(reconcilerOpts, managed.WithManagementPolicies())
 	}
 
@@ -126,7 +127,6 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}
 
 	groupLink, _, err := e.client.GetGroupSAMLLink(*cr.Spec.ForProvider.GroupID, samlGroupName)
-
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(resource.Ignore(groups.IsErrorSamlGroupLinkNotFound, err), errGetFailed)
 	}

--- a/pkg/controller/groups/variables/controller.go
+++ b/pkg/controller/groups/variables/controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/crossplane/crossplane-runtime/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/statemetrics"
@@ -70,7 +71,7 @@ func SetupVariable(mgr ctrl.Manager, o controller.Options) error {
 		managed.WithConnectionPublishers(cps...),
 	}
 
-	if o.Features.Enabled(features.EnableAlphaManagementPolicies) {
+	if o.Features.Enabled(feature.EnableBetaManagementPolicies) {
 		reconcilerOpts = append(reconcilerOpts, managed.WithManagementPolicies())
 	}
 
@@ -124,7 +125,6 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		*cr.Spec.ForProvider.GroupID,
 		cr.Spec.ForProvider.Key,
 		gitlab.WithContext(ctx))
-
 	if err != nil {
 		if clients.IsResponseNotFound(res) {
 			return managed.ExternalObservation{}, nil
@@ -170,7 +170,6 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		*cr.Spec.ForProvider.GroupID,
 		groups.GenerateCreateVariableOptions(&cr.Spec.ForProvider),
 		gitlab.WithContext(ctx))
-
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreateFailed)
 	}

--- a/pkg/controller/projects/accesstokens/controller.go
+++ b/pkg/controller/projects/accesstokens/controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/connection"
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/crossplane/crossplane-runtime/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -72,7 +73,7 @@ func SetupAccessToken(mgr ctrl.Manager, o controller.Options) error {
 		managed.WithConnectionPublishers(cps...),
 	}
 
-	if o.Features.Enabled(features.EnableAlphaManagementPolicies) {
+	if o.Features.Enabled(feature.EnableBetaManagementPolicies) {
 		reconcilerOpts = append(reconcilerOpts, managed.WithManagementPolicies())
 	}
 
@@ -168,7 +169,6 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		projects.GenerateCreateProjectAccessTokenOptions(cr.Name, &cr.Spec.ForProvider),
 		gitlab.WithContext(ctx),
 	)
-
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreateFailed)
 	}
@@ -193,7 +193,6 @@ func (e *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 
 	accessTokenID, err := strconv.Atoi(meta.GetExternalName(cr))
-
 	if err != nil {
 		return managed.ExternalDelete{}, errors.New(errExternalNameNotInt)
 	}

--- a/pkg/controller/projects/deploykeys/controller.go
+++ b/pkg/controller/projects/deploykeys/controller.go
@@ -8,6 +8,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/connection"
 	crpc "github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/crossplane/crossplane-runtime/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -68,7 +69,7 @@ func SetupDeployKey(mgr ctrl.Manager, o crpc.Options) error {
 		managed.WithConnectionPublishers(cps...),
 	}
 
-	if o.Features.Enabled(features.EnableAlphaManagementPolicies) {
+	if o.Features.Enabled(feature.EnableBetaManagementPolicies) {
 		reconcilerOpts = append(reconcilerOpts, managed.WithManagementPolicies())
 	}
 
@@ -95,7 +96,6 @@ func (c *connector) Connect(ctx context.Context, mgd resource.Managed) (managed.
 	}
 
 	config, err := clients.GetConfig(ctx, c.kube, cr)
-
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +115,6 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}
 
 	id, err := strconv.Atoi(meta.GetExternalName(cr))
-
 	if err != nil {
 		return managed.ExternalObservation{}, errors.New(errIDNotAnInt)
 	}
@@ -124,7 +123,6 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		*cr.Spec.ForProvider.ProjectID,
 		id,
 	)
-
 	if err != nil {
 		if clients.IsResponseNotFound(res) {
 			return managed.ExternalObservation{}, nil
@@ -171,7 +169,6 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 
 	secret := &corev1.Secret{}
 	err := e.kube.Get(ctx, namespacedName, secret)
-
 	if err != nil {
 		return managed.ExternalCreation{},
 			errors.Wrap(err, errKeyMissing)
@@ -182,7 +179,6 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		generateCreateOptions(string(secret.Data[keySecretRef.Key]), &cr.Spec.ForProvider),
 		gitlab.WithContext(ctx),
 	)
-
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreateFail)
 	}
@@ -206,7 +202,6 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 
 	idString := meta.GetExternalName(cr)
 	id, err := strconv.Atoi(idString)
-
 	if err != nil {
 		return managed.ExternalUpdate{}, errors.Wrap(err, errIDNotAnInt)
 	}
@@ -233,7 +228,6 @@ func (e *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 
 	keyIDString := meta.GetExternalName(cr)
 	keyID, err := strconv.Atoi(keyIDString)
-
 	if err != nil {
 		return managed.ExternalDelete{}, errors.Wrap(err, errIDNotAnInt)
 	}

--- a/pkg/controller/projects/deploytokens/controller.go
+++ b/pkg/controller/projects/deploytokens/controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/connection"
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/crossplane/crossplane-runtime/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -69,7 +70,7 @@ func SetupDeployToken(mgr ctrl.Manager, o controller.Options) error {
 		managed.WithConnectionPublishers(cps...),
 	}
 
-	if o.Features.Enabled(features.EnableAlphaManagementPolicies) {
+	if o.Features.Enabled(feature.EnableBetaManagementPolicies) {
 		reconcilerOpts = append(reconcilerOpts, managed.WithManagementPolicies())
 	}
 
@@ -131,7 +132,6 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}
 
 	dt, res, err := e.client.GetProjectDeployToken(*cr.Spec.ForProvider.ProjectID, id)
-
 	if err != nil {
 		if clients.IsResponseNotFound(res) {
 			return managed.ExternalObservation{}, nil
@@ -166,7 +166,6 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		projects.GenerateCreateProjectDeployTokenOptions(cr.Name, &cr.Spec.ForProvider),
 		gitlab.WithContext(ctx),
 	)
-
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreateFailed)
 	}

--- a/pkg/controller/projects/hooks/controller.go
+++ b/pkg/controller/projects/hooks/controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/connection"
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/crossplane/crossplane-runtime/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -70,7 +71,7 @@ func SetupHook(mgr ctrl.Manager, o controller.Options) error {
 		managed.WithConnectionPublishers(cps...),
 	}
 
-	if o.Features.Enabled(features.EnableAlphaManagementPolicies) {
+	if o.Features.Enabled(feature.EnableBetaManagementPolicies) {
 		reconcilerOpts = append(reconcilerOpts, managed.WithManagementPolicies())
 	}
 
@@ -160,13 +161,11 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 
 	cr.Status.SetConditions(xpv1.Creating())
 	hookOptions, err := projects.GenerateCreateHookOptions(&cr.Spec.ForProvider, e.kube, ctx)
-
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errSecretRefInvalid)
 	}
 
 	hook, _, err := e.client.AddProjectHook(*cr.Spec.ForProvider.ProjectID, hookOptions, gitlab.WithContext(ctx))
-
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreateFailed)
 	}
@@ -190,7 +189,6 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 
 	editHookOptions, err := projects.GenerateEditHookOptions(&cr.Spec.ForProvider, e.kube, ctx)
-
 	if err != nil {
 		return managed.ExternalUpdate{}, errors.New(errSecretRefInvalid)
 	}

--- a/pkg/controller/projects/members/controller.go
+++ b/pkg/controller/projects/members/controller.go
@@ -20,6 +20,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/connection"
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/crossplane/crossplane-runtime/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/statemetrics"
@@ -70,7 +71,7 @@ func SetupMember(mgr ctrl.Manager, o controller.Options) error {
 		managed.WithConnectionPublishers(cps...),
 	}
 
-	if o.Features.Enabled(features.EnableAlphaManagementPolicies) {
+	if o.Features.Enabled(feature.EnableBetaManagementPolicies) {
 		reconcilerOpts = append(reconcilerOpts, managed.WithManagementPolicies())
 	}
 
@@ -138,7 +139,6 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		*cr.Spec.ForProvider.ProjectID,
 		*cr.Spec.ForProvider.UserID,
 	)
-
 	if err != nil {
 		if clients.IsResponseNotFound(res) {
 			return managed.ExternalObservation{}, nil

--- a/pkg/controller/projects/pipelineschedules/controller.go
+++ b/pkg/controller/projects/pipelineschedules/controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/connection"
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/crossplane/crossplane-runtime/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -74,7 +75,7 @@ func SetupPipelineSchedule(mgr ctrl.Manager, o controller.Options) error {
 		managed.WithConnectionPublishers(cps...),
 	}
 
-	if o.Features.Enabled(features.EnableAlphaManagementPolicies) {
+	if o.Features.Enabled(feature.EnableBetaManagementPolicies) {
 		reconcilerOpts = append(reconcilerOpts, managed.WithManagementPolicies())
 	}
 
@@ -143,7 +144,6 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}
 
 	ps, res, err := e.client.GetPipelineSchedule(*cr.Spec.ForProvider.ProjectID, id)
-
 	if err != nil {
 		if clients.IsResponseNotFound(res) {
 			return managed.ExternalObservation{}, nil
@@ -183,7 +183,6 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 
 	ps, _, err := e.client.CreatePipelineSchedule(*cr.Spec.ForProvider.ProjectID, opt)
-
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreatePipelineSchedule)
 	}
@@ -240,7 +239,6 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		id,
 		opt,
 	)
-
 	if err != nil {
 		return managed.ExternalUpdate{}, errors.Wrap(err, errUpdatePipelineSchedule)
 	}
@@ -348,7 +346,8 @@ func lateInitialize(cr *v1alpha1.PipelineScheduleParameters, ps *gitlab.Pipeline
 			varr[i] = v1alpha1.PipelineVariable{
 				Key:          vv.Key,
 				Value:        vv.Value,
-				VariableType: (*string)(&vv.VariableType)}
+				VariableType: (*string)(&vv.VariableType),
+			}
 		}
 		cr.Variables = varr
 	}
@@ -379,7 +378,6 @@ func isVariablesUpToDate(crv []v1alpha1.PipelineVariable, inv []*gitlab.Pipeline
 		return false
 	}
 	for _, v := range crv {
-
 		if notSaved(v, inv) {
 			return false
 		}

--- a/pkg/controller/projects/projects/project.go
+++ b/pkg/controller/projects/projects/project.go
@@ -24,6 +24,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/connection"
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/crossplane/crossplane-runtime/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -69,7 +70,7 @@ func SetupProject(mgr ctrl.Manager, o controller.Options) error {
 		managed.WithConnectionPublishers(cps...),
 	}
 
-	if o.Features.Enabled(features.EnableAlphaManagementPolicies) {
+	if o.Features.Enabled(feature.EnableBetaManagementPolicies) {
 		reconcilerOpts = append(reconcilerOpts, managed.WithManagementPolicies())
 	}
 

--- a/pkg/controller/projects/variables/controller.go
+++ b/pkg/controller/projects/variables/controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/crossplane/crossplane-runtime/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/statemetrics"
@@ -70,7 +71,7 @@ func SetupVariable(mgr ctrl.Manager, o controller.Options) error {
 		managed.WithConnectionPublishers(cps...),
 	}
 
-	if o.Features.Enabled(features.EnableAlphaManagementPolicies) {
+	if o.Features.Enabled(feature.EnableBetaManagementPolicies) {
 		reconcilerOpts = append(reconcilerOpts, managed.WithManagementPolicies())
 	}
 
@@ -125,7 +126,6 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		cr.Spec.ForProvider.Key,
 		projects.GenerateGetVariableOptions(&cr.Spec.ForProvider),
 		gitlab.WithContext(ctx))
-
 	if err != nil {
 		if clients.IsResponseNotFound(res) {
 			return managed.ExternalObservation{}, nil
@@ -171,7 +171,6 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		*cr.Spec.ForProvider.ProjectID,
 		projects.GenerateCreateVariableOptions(&cr.Spec.ForProvider),
 		gitlab.WithContext(ctx))
-
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreateFailed)
 	}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -24,9 +24,4 @@ const (
 	// External Secret Stores. See the below design for more details.
 	// https://github.com/crossplane/crossplane/blob/390ddd/design/design-doc-external-secret-stores.md
 	EnableAlphaExternalSecretStores feature.Flag = "EnableAlphaExternalSecretStores"
-
-	// EnableAlphaManagementPolicies enables alpha support for
-	// Management Policies. See the below design for more details.
-	// https://github.com/crossplane/crossplane/pull/3531
-	EnableAlphaManagementPolicies feature.Flag = "EnableAlphaManagementPolicies"
 )


### PR DESCRIPTION
### Description of your changes
This PR promotes the ManagementPolicies from an alpha feature to a beta feature.
This aligns with the promotion crossplane did while moving to 1.17+.

Fixes #169

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Unit tests and deployed internally.

[contribution process]: https://git.io/fj2m9
