### PR TITLE
fix ExternalSecretStores feature fail to start, fixes #175

### DIFF
--- a/apis/gitlab.go
+++ b/apis/gitlab.go
@@ -22,6 +22,7 @@ import (
 
 	groupsv1alpha1 "github.com/crossplane-contrib/provider-gitlab/apis/groups/v1alpha1"
 	projectsv1alpha1 "github.com/crossplane-contrib/provider-gitlab/apis/projects/v1alpha1"
+	gitlabv1alpha1 "github.com/crossplane-contrib/provider-gitlab/apis/v1alpha1"
 	gitlabv1beta1 "github.com/crossplane-contrib/provider-gitlab/apis/v1beta1"
 )
 
@@ -31,6 +32,7 @@ func init() {
 		gitlabv1beta1.SchemeBuilder.AddToScheme,
 		groupsv1alpha1.SchemeBuilder.AddToScheme,
 		projectsv1alpha1.SchemeBuilder.AddToScheme,
+		gitlabv1alpha1.SchemeBuilder.AddToScheme,
 	)
 }
 


### PR DESCRIPTION
### Description of your changes

Fixes ExternalSecretStores feature prevention to crash the application 

Fixes https://github.com/crossplane-contrib/provider-gitlab/issues/175

I have:

- [x] Read and followed Crossplane's [contribution process](https://git.io/fj2m9).
- [x] Run make reviewable test to ensure this PR is ready for review.

### How has this code been tested

Running compiled binary locally with flag enabled

Detail for fix
Registering missing scheme: 

```
func init() {
	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
	AddToSchemes = append(AddToSchemes,
		gitlabv1beta1.SchemeBuilder.AddToScheme,
		groupsv1alpha1.SchemeBuilder.AddToScheme,
		projectsv1alpha1.SchemeBuilder.AddToScheme,
		gitlabv1alpha1.SchemeBuilder.AddToScheme, // HERE
	)
}
```
