### PR TITLE
fix(client): map AuthMethod for different supported token types

### DIFF
--- a/pkg/clients/gitlab.go
+++ b/pkg/clients/gitlab.go
@@ -135,6 +135,7 @@ func UseProviderConfig(ctx context.Context, c client.Client, mg resource.Managed
 			BaseURL:            pc.Spec.BaseURL,
 			Token:              string(s.Data[csr.Key]),
 			InsecureSkipVerify: ptr.Deref(pc.Spec.InsecureSkipVerify, false),
+			AuthMethod:         pc.Spec.Credentials.Method,
 		}, nil
 	default:
 		return nil, errors.Errorf("credentials source %s is not currently supported", s)


### PR DESCRIPTION
### Description of your changes

This issue fixes the mapping between the different supported Credential Method (BasicAuth, JobToken, OAuthToken or PersonalAccessToken) defined in the ProviderConfig.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review. (I ran it but there are issues in apis/groups unrelated to this PR)

### How has this code been tested

I have run this on my cluster and have got a positive status on a `Hook.projects.gitlab.crossplane.io` ressource

[contribution process]: https://git.io/fj2m9
