### PR TITLE
fix: pass options to basic auth client

### DIFF
--- a/pkg/clients/gitlab.go
+++ b/pkg/clients/gitlab.go
@@ -81,7 +81,7 @@ func NewClient(c Config) *gitlab.Client {
 		if err = json.Unmarshal([]byte(c.Token), ba); err != nil {
 			panic(err)
 		}
-		cl, err = gitlab.NewBasicAuthClient(ba.Username, ba.Password, gitlab.WithBaseURL(c.BaseURL))
+		cl, err = gitlab.NewBasicAuthClient(ba.Username, ba.Password, options...)
 	case v1beta1.JobToken:
 		cl, err = gitlab.NewJobClient(c.Token, options...)
 	case v1beta1.OAuthToken:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

The Basic Auth client does not get the same options passed to it as the other clients. This is inconvenient because it removes the ability to use the `InsecureSkipVerify` option.

This PR configures the Basic Auth client like all the others.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Ran `build run` and verified that the Basic Auth client works with the `InsecureSkipVerify` option.

Used this PR's version of the provider to create a project and group within Gitlab with no issues using the Basic Auth client.

[contribution process]: https://git.io/fj2m9
