### PR TITLE
chore: update gitlab client-go to version v0.127.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/crossplane/crossplane-tools v0.0.0-20250424174524-de0e5107ea45
 	github.com/google/go-cmp v0.7.0
 	github.com/pkg/errors v0.9.1
-	gitlab.com/gitlab-org/api/client-go v0.123.0
+	gitlab.com/gitlab-org/api/client-go v0.127.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	k8s.io/api v0.32.3
 	k8s.io/apimachinery v0.32.3

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8
 github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-gitlab.com/gitlab-org/api/client-go v0.123.0 h1:W3LZ5QNyiSCJA0Zchkwz8nQIUzOuDoSWMZtRDT5DjPI=
-gitlab.com/gitlab-org/api/client-go v0.123.0/go.mod h1:Jh0qjLILEdbO6z/OY94RD+3NDQRUKiuFSFYozN6cpKM=
+gitlab.com/gitlab-org/api/client-go v0.127.0 h1:8xnxcNKGF2gDazEoMs+hOZfOspSSw8D0vAoWhQk9U+U=
+gitlab.com/gitlab-org/api/client-go v0.127.0/go.mod h1:bYC6fPORKSmtuPRyD9Z2rtbAjE7UeNatu2VWHRf4/LE=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/otel v1.34.0 h1:zRLXxLCgL1WyKsPVrgbSdMN4c0FMkDAskSTQP+0hdUY=

--- a/pkg/clients/groups/fake/fake.go
+++ b/pkg/clients/groups/fake/fake.go
@@ -162,7 +162,7 @@ func (c *MockClient) UpdateVariable(gid interface{}, key string, opt *gitlab.Upd
 }
 
 // RemoveVariable calls the underlying MockRemoveGroupVariable method.
-func (c *MockClient) RemoveVariable(gid interface{}, key string, options ...gitlab.RequestOptionFunc) (*gitlab.Response, error) {
+func (c *MockClient) RemoveVariable(gid interface{}, key string, opt *gitlab.RemoveGroupVariableOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Response, error) {
 	return c.MockRemoveGroupVariable(gid, key)
 }
 

--- a/pkg/clients/groups/group_test.go
+++ b/pkg/clients/groups/group_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"gitlab.com/gitlab-org/api/client-go"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/crossplane-contrib/provider-gitlab/apis/groups/v1alpha1"
@@ -120,14 +120,7 @@ func TestGenerateObservation(t *testing.T) {
 							Value: customAttributeValue,
 						},
 					},
-					SharedWithGroups: []struct {
-						GroupID          int             `json:"group_id"`
-						GroupName        string          `json:"group_name"`
-						GroupFullPath    string          `json:"group_full_path"`
-						GroupAccessLevel int             `json:"group_access_level"`
-						ExpiresAt        *gitlab.ISOTime `json:"expires_at"`
-						MemberRoleID     int             `json:"member_role_id"`
-					}{
+					SharedWithGroups: []gitlab.SharedWithGroup{
 						{
 							GroupID:          ID,
 							GroupName:        name,
@@ -187,14 +180,7 @@ func TestGenerateObservation(t *testing.T) {
 		"SharedWithGroupExpiresAtIsNil": {
 			args: args{
 				p: &gitlab.Group{
-					SharedWithGroups: []struct {
-						GroupID          int             `json:"group_id"`
-						GroupName        string          `json:"group_name"`
-						GroupFullPath    string          `json:"group_full_path"`
-						GroupAccessLevel int             `json:"group_access_level"`
-						ExpiresAt        *gitlab.ISOTime `json:"expires_at"`
-						MemberRoleID     int             `json:"member_role_id"`
-					}{
+					SharedWithGroups: []gitlab.SharedWithGroup{
 						{
 							ExpiresAt: nil,
 						},

--- a/pkg/clients/groups/variable.go
+++ b/pkg/clients/groups/variable.go
@@ -38,7 +38,7 @@ type VariableClient interface {
 	GetVariable(gid interface{}, key string, opt *gitlab.GetGroupVariableOptions, options ...gitlab.RequestOptionFunc) (*gitlab.GroupVariable, *gitlab.Response, error)
 	CreateVariable(gid interface{}, opt *gitlab.CreateGroupVariableOptions, options ...gitlab.RequestOptionFunc) (*gitlab.GroupVariable, *gitlab.Response, error)
 	UpdateVariable(gid interface{}, key string, opt *gitlab.UpdateGroupVariableOptions, options ...gitlab.RequestOptionFunc) (*gitlab.GroupVariable, *gitlab.Response, error)
-	RemoveVariable(gid interface{}, key string, options ...gitlab.RequestOptionFunc) (*gitlab.Response, error)
+	RemoveVariable(gid interface{}, key string, opt *gitlab.RemoveGroupVariableOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Response, error)
 }
 
 // NewVariableClient returns a new Gitlab Group service

--- a/pkg/controller/groups/accesstokens/controller_test.go
+++ b/pkg/controller/groups/accesstokens/controller_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
-	"gitlab.com/gitlab-org/api/client-go"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -52,11 +52,13 @@ var (
 	name           = "Access Token Name"
 	token          = "Token"
 	accessTokenObj = gitlab.GroupAccessToken{
-		ID:          accessTokenID,
-		Name:        name,
-		ExpiresAt:   (*gitlab.ISOTime)(&expiresAt),
-		Token:       token,
-		Scopes:      []string{"scope1", "scope2"},
+		PersonalAccessToken: gitlab.PersonalAccessToken{
+			ID:        accessTokenID,
+			Name:      name,
+			ExpiresAt: (*gitlab.ISOTime)(&expiresAt),
+			Token:     token,
+			Scopes:    []string{"scope1", "scope2"},
+		},
 		AccessLevel: 40, // Access level. Valid values are 10 (Guest), 20 (Reporter), 30 (Developer), 40 (Maintainer), and 50 (Owner). Defaults to 40.
 	}
 
@@ -256,7 +258,9 @@ func TestObserve(t *testing.T) {
 				accessTokenClient: &fake.MockClient{
 					MockGetGroupAccessToken: func(pid interface{}, id int, options ...gitlab.RequestOptionFunc) (*gitlab.GroupAccessToken, *gitlab.Response, error) {
 						return &gitlab.GroupAccessToken{
-							ExpiresAt:   accessTokenObj.ExpiresAt,
+							PersonalAccessToken: gitlab.PersonalAccessToken{
+								ExpiresAt: accessTokenObj.ExpiresAt,
+							},
 							AccessLevel: accessTokenObj.AccessLevel,
 						}, &gitlab.Response{}, nil
 					},

--- a/pkg/controller/groups/groups/group_test.go
+++ b/pkg/controller/groups/groups/group_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
-	"gitlab.com/gitlab-org/api/client-go"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -307,14 +307,7 @@ func TestObserve(t *testing.T) {
 						return &gitlab.Group{
 							Path:         "",
 							RunnersToken: "token",
-							SharedWithGroups: []struct {
-								GroupID          int             "json:\"group_id\""
-								GroupName        string          "json:\"group_name\""
-								GroupFullPath    string          "json:\"group_full_path\""
-								GroupAccessLevel int             "json:\"group_access_level\""
-								ExpiresAt        *gitlab.ISOTime "json:\"expires_at\""
-								MemberRoleID     int             "json:\"member_role_id\""
-							}{
+							SharedWithGroups: []gitlab.SharedWithGroup{
 								{
 									GroupID:          groupID,
 									GroupName:        name,
@@ -670,14 +663,7 @@ func TestUpdate(t *testing.T) {
 					MockUpdateGroup: func(pid interface{}, opt *gitlab.UpdateGroupOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Group, *gitlab.Response, error) {
 						return &gitlab.Group{
 							ID: groupID,
-							SharedWithGroups: []struct {
-								GroupID          int             "json:\"group_id\""
-								GroupName        string          "json:\"group_name\""
-								GroupFullPath    string          "json:\"group_full_path\""
-								GroupAccessLevel int             "json:\"group_access_level\""
-								ExpiresAt        *gitlab.ISOTime "json:\"expires_at\""
-								MemberRoleID     int             "json:\"member_role_id\""
-							}{
+							SharedWithGroups: []gitlab.SharedWithGroup{
 								{
 									GroupID: groupID,
 								},
@@ -725,14 +711,7 @@ func TestUpdate(t *testing.T) {
 				group: &fake.MockClient{
 					MockUpdateGroup: func(pid interface{}, opt *gitlab.UpdateGroupOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Group, *gitlab.Response, error) {
 						return &gitlab.Group{
-							SharedWithGroups: []struct {
-								GroupID          int             "json:\"group_id\""
-								GroupName        string          "json:\"group_name\""
-								GroupFullPath    string          "json:\"group_full_path\""
-								GroupAccessLevel int             "json:\"group_access_level\""
-								ExpiresAt        *gitlab.ISOTime "json:\"expires_at\""
-								MemberRoleID     int             "json:\"member_role_id\""
-							}{
+							SharedWithGroups: []gitlab.SharedWithGroup{
 								{GroupID: groupID},
 								{GroupID: 123456},
 							},
@@ -797,14 +776,7 @@ func TestUpdate(t *testing.T) {
 				group: &fake.MockClient{
 					MockUpdateGroup: func(pid interface{}, opt *gitlab.UpdateGroupOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Group, *gitlab.Response, error) {
 						return &gitlab.Group{
-							SharedWithGroups: []struct {
-								GroupID          int             "json:\"group_id\""
-								GroupName        string          "json:\"group_name\""
-								GroupFullPath    string          "json:\"group_full_path\""
-								GroupAccessLevel int             "json:\"group_access_level\""
-								ExpiresAt        *gitlab.ISOTime "json:\"expires_at\""
-								MemberRoleID     int             "json:\"member_role_id\""
-							}{
+							SharedWithGroups: []gitlab.SharedWithGroup{
 								{GroupID: groupID},
 								{GroupID: 123456},
 							},

--- a/pkg/controller/groups/variables/controller.go
+++ b/pkg/controller/groups/variables/controller.go
@@ -211,10 +211,15 @@ func (e *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalDelete{}, errors.New(errGroupIDMissing)
 	}
 
+	opts := &gitlab.RemoveGroupVariableOptions{
+		Filter: nil,
+	}
+
 	cr.Status.SetConditions(xpv1.Deleting())
 	_, err := e.client.RemoveVariable(
 		*cr.Spec.ForProvider.GroupID,
 		cr.Spec.ForProvider.Key,
+		opts,
 		gitlab.WithContext(ctx),
 	)
 	return managed.ExternalDelete{}, errors.Wrap(err, errDeleteFailed)

--- a/pkg/controller/projects/accesstokens/controller_test.go
+++ b/pkg/controller/projects/accesstokens/controller_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
-	"gitlab.com/gitlab-org/api/client-go"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -52,11 +52,13 @@ var (
 	name           = "Access Token Name"
 	token          = "Token"
 	accessTokenObj = gitlab.ProjectAccessToken{
-		ID:          accessTokenID,
-		Name:        name,
-		ExpiresAt:   (*gitlab.ISOTime)(&expiresAt),
-		Token:       token,
-		Scopes:      []string{"scope1", "scope2"},
+		PersonalAccessToken: gitlab.PersonalAccessToken{
+			ID:        accessTokenID,
+			Name:      name,
+			ExpiresAt: (*gitlab.ISOTime)(&expiresAt),
+			Token:     token,
+			Scopes:    []string{"scope1", "scope2"},
+		},
 		AccessLevel: 40, // Access level. Valid values are 10 (Guest), 20 (Reporter), 30 (Developer), 40 (Maintainer), and 50 (Owner). Defaults to 40.
 	}
 
@@ -256,7 +258,9 @@ func TestObserve(t *testing.T) {
 				accessTokenClient: &fake.MockClient{
 					MockGetProjectAccessToken: func(pid interface{}, id int, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectAccessToken, *gitlab.Response, error) {
 						return &gitlab.ProjectAccessToken{
-							ExpiresAt:   accessTokenObj.ExpiresAt,
+							PersonalAccessToken: gitlab.PersonalAccessToken{
+								ExpiresAt: accessTokenObj.ExpiresAt,
+							},
 							AccessLevel: accessTokenObj.AccessLevel,
 						}, &gitlab.Response{}, nil
 					},


### PR DESCRIPTION
### Description of your changes

* update of the Gitlab client-go dependency to [v0.127.0](https://gitlab.com/gitlab-org/api/client-go/-/releases/v0.127.0)

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
