### PR TITLE
fix: dereference projectId for UpdateDeployKey call

### DIFF
--- a/pkg/controller/projects/deploykeys/controller.go
+++ b/pkg/controller/projects/deploykeys/controller.go
@@ -207,7 +207,7 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 
 	_, _, er := e.client.UpdateDeployKey(
-		cr.Spec.ForProvider.ProjectID,
+		*cr.Spec.ForProvider.ProjectID,
 		id,
 		generateUpdateOptions(cr),
 	)


### PR DESCRIPTION
### Description of your changes

* Dereferenced ProjectID in the UpdateDeployKey call.

Fixes #198

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
