### PR TITLE
feat(group): Add option to treat pending deletion as deleted

### DIFF
--- a/apis/groups/v1alpha1/group_types.go
+++ b/apis/groups/v1alpha1/group_types.go
@@ -164,6 +164,11 @@ type GroupParameters struct {
 	// +optional
 	PermanentlyRemove *bool `json:"permanentlyRemove,omitempty"`
 
+	// RemoveFinalizerOnPendingDeletion specifies wether the finalizer of this
+	// object should be removed in case the Kubernetes object and
+	// the external Gitlab group are marked for pending deletion.
+	RemoveFinalizerOnPendingDeletion *bool `json:"removeFinalizerOnPendingDeletion,omitempty"`
+
 	// Full path of group to delete permanently. Only required if PermanentlyRemove is set to true.
 	// GitLab Premium and Ultimate only.
 	// +optional

--- a/apis/groups/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/groups/v1alpha1/zz_generated.deepcopy.go
@@ -603,6 +603,11 @@ func (in *GroupParameters) DeepCopyInto(out *GroupParameters) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.RemoveFinalizerOnPendingDeletion != nil {
+		in, out := &in.RemoveFinalizerOnPendingDeletion, &out.RemoveFinalizerOnPendingDeletion
+		*out = new(bool)
+		**out = **in
+	}
 	if in.FullPathToRemove != nil {
 		in, out := &in.FullPathToRemove, &out.FullPathToRemove
 		*out = new(string)

--- a/package/crds/groups.gitlab.crossplane.io_groups.yaml
+++ b/package/crds/groups.gitlab.crossplane.io_groups.yaml
@@ -208,6 +208,12 @@ spec:
                       developers can create projects in the group.
                       Can be noone (No one), maintainer (Maintainers), or developer (Developers + Maintainers).
                     type: string
+                  removeFinalizerOnPendingDeletion:
+                    description: |-
+                      RemoveFinalizerOnPendingDeletion specifies wether the finalizer of this
+                      object should be removed in case the Kubernetes object and
+                      the external Gitlab group are marked for pending deletion.
+                    type: boolean
                   requestAccessEnabled:
                     description: Allow users to request member access.
                     type: boolean


### PR DESCRIPTION
### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds a new property to specify if the controller should treat groups in pending deletion state as deleted.

Relates to https://github.com/crossplane-contrib/provider-gitlab/pull/212 and #207.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually

[contribution process]: https://git.io/fj2m9
