### PR TITLE
fix: only apply pushrules on gitlab enterprise edition

### DIFF
--- a/pkg/clients/projects/project.go
+++ b/pkg/clients/projects/project.go
@@ -426,6 +426,25 @@ func GenerateEditPushRulesOptions(p *v1alpha1.ProjectParameters) *gitlab.EditPro
 		o.PreventSecrets = p.PushRules.PreventSecrets
 		o.RejectNonDCOCommits = p.PushRules.RejectNonDCOCommits
 		o.RejectUnsignedCommits = p.PushRules.RejectUnsignedCommits
+	} else {
+		// When push rules are removed from spec, clear all rules by setting them to empty/false values
+		emptyString := ""
+		falseValue := false
+		zeroInt := 0
+
+		o.AuthorEmailRegex = &emptyString
+		o.BranchNameRegex = &emptyString
+		o.CommitCommitterCheck = &falseValue
+		o.CommitCommitterNameCheck = &falseValue
+		o.CommitMessageNegativeRegex = &emptyString
+		o.CommitMessageRegex = &emptyString
+		o.DenyDeleteTag = &falseValue
+		o.FileNameRegex = &emptyString
+		o.MaxFileSize = &zeroInt
+		o.MemberCheck = &falseValue
+		o.PreventSecrets = &falseValue
+		o.RejectNonDCOCommits = &falseValue
+		o.RejectUnsignedCommits = &falseValue
 	}
 	return o
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
only apply pushrules on gitlab enterprise edition
also fixed a bug when removing pushrules to set them back to the default values

Fixes #223

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

tested locally on a community edition instance and a enterprise instance with premium features enabled

[contribution process]: https://git.io/fj2m9
