### PR TITLE
feat(variables): skip secret lookup during deletion

### DIFF
--- a/pkg/cluster/controller/groups/variables/zz_controller.go
+++ b/pkg/cluster/controller/groups/variables/zz_controller.go
@@ -133,6 +133,11 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.Wrap(err, errGetFailed)
 	}
 
+	// Deleting: only need to determine external resource still exists.
+	if !cr.ObjectMeta.DeletionTimestamp.IsZero() {
+		return managed.ExternalObservation{ResourceExists: true}, nil
+	}
+
 	if cr.Spec.ForProvider.ValueSecretRef != nil {
 		if err = e.updateVariableFromSecret(mg, ctx, cr.Spec.ForProvider.ValueSecretRef, &cr.Spec.ForProvider); err != nil {
 			return managed.ExternalObservation{}, errors.Wrap(err, errUpdateFailed)

--- a/pkg/cluster/controller/groups/variables/zz_controller_test.go
+++ b/pkg/cluster/controller/groups/variables/zz_controller_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane-contrib/provider-gitlab/apis/cluster/groups/v1alpha1"
@@ -132,6 +133,14 @@ func withVariableType(variableType v1alpha1.VariableType) variableModifier {
 func withEnvironmentScope(scope string) variableModifier {
 	return func(r *v1alpha1.Variable) {
 		r.Spec.ForProvider.EnvironmentScope = &scope
+	}
+}
+
+var deletionTime = metav1.Now()
+
+func withDeletionTimestamp() variableModifier {
+	return func(r *v1alpha1.Variable) {
+		r.ObjectMeta.DeletionTimestamp = &deletionTime
 	}
 }
 
@@ -360,6 +369,36 @@ func TestObserve(t *testing.T) {
 					withValueSecretRef(common.TestCreateSecretKeySelector("something", "bad")),
 				),
 				err: errors.Wrap(errors.New(common.ErrSecretKeyNotFound), errGetFailed),
+			},
+		},
+
+		"DeletingEarlyReturnSkipsSecret": {
+			args: args{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error { return errBoom },
+				},
+				variable: &fake.MockClient{
+					MockGetGroupVariable: func(gid interface{}, key string, opt *gitlab.GetGroupVariableOptions, options ...gitlab.RequestOptionFunc) (*gitlab.GroupVariable, *gitlab.Response, error) {
+						return &pv, &gitlab.Response{}, nil
+					},
+				},
+				cr: variable(
+					withGroupID(groupID),
+					withKey(variableKey),
+					withValueSecretRef(common.TestCreateSecretKeySelector("something", "blah")),
+					withDeletionTimestamp(),
+					withConditions(xpv1.Deleting()),
+				),
+			},
+			want: want{
+				cr: variable(
+					withGroupID(groupID),
+					withKey(variableKey),
+					withValueSecretRef(common.TestCreateSecretKeySelector("something", "blah")),
+					withDeletionTimestamp(),
+					withConditions(xpv1.Deleting()),
+				),
+				result: managed.ExternalObservation{ResourceExists: true},
 			},
 		},
 	}

--- a/pkg/cluster/controller/projects/variables/zz_controller.go
+++ b/pkg/cluster/controller/projects/variables/zz_controller.go
@@ -133,6 +133,11 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.Wrap(err, errGetFailed)
 	}
 
+	// Deleting: only need to determine external resource still exists.
+	if !cr.ObjectMeta.DeletionTimestamp.IsZero() {
+		return managed.ExternalObservation{ResourceExists: true}, nil
+	}
+
 	if cr.Spec.ForProvider.ValueSecretRef != nil {
 		if err = e.updateVariableFromSecret(mg, ctx, cr.Spec.ForProvider.ValueSecretRef, &cr.Spec.ForProvider); err != nil {
 			return managed.ExternalObservation{}, errors.Wrap(err, errUpdateFailed)

--- a/pkg/namespaced/controller/groups/variables/controller.go
+++ b/pkg/namespaced/controller/groups/variables/controller.go
@@ -131,6 +131,11 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.Wrap(err, errGetFailed)
 	}
 
+	// Deleting: only need to determine external resource still exists.
+	if !cr.ObjectMeta.DeletionTimestamp.IsZero() {
+		return managed.ExternalObservation{ResourceExists: true}, nil
+	}
+
 	if cr.Spec.ForProvider.ValueSecretRef != nil {
 		if err = e.updateVariableFromSecret(mg, ctx, cr.Spec.ForProvider.ValueSecretRef, &cr.Spec.ForProvider); err != nil {
 			return managed.ExternalObservation{}, errors.Wrap(err, errUpdateFailed)

--- a/pkg/namespaced/controller/groups/variables/controller_test.go
+++ b/pkg/namespaced/controller/groups/variables/controller_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane-contrib/provider-gitlab/apis/namespaced/groups/v1alpha1"
@@ -130,6 +131,14 @@ func withVariableType(variableType v1alpha1.VariableType) variableModifier {
 func withEnvironmentScope(scope string) variableModifier {
 	return func(r *v1alpha1.Variable) {
 		r.Spec.ForProvider.EnvironmentScope = &scope
+	}
+}
+
+var deletionTime = metav1.Now()
+
+func withDeletionTimestamp() variableModifier {
+	return func(r *v1alpha1.Variable) {
+		r.ObjectMeta.DeletionTimestamp = &deletionTime
 	}
 }
 
@@ -358,6 +367,36 @@ func TestObserve(t *testing.T) {
 					withValueSecretRef(common.TestCreateLocalSecretKeySelector("something", "bad")),
 				),
 				err: errors.Wrap(errors.New(common.ErrSecretKeyNotFound), errGetFailed),
+			},
+		},
+
+		"DeletingEarlyReturnSkipsSecret": {
+			args: args{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error { return errBoom },
+				},
+				variable: &fake.MockClient{
+					MockGetGroupVariable: func(gid interface{}, key string, opt *gitlab.GetGroupVariableOptions, options ...gitlab.RequestOptionFunc) (*gitlab.GroupVariable, *gitlab.Response, error) {
+						return &pv, &gitlab.Response{}, nil
+					},
+				},
+				cr: variable(
+					withGroupID(groupID),
+					withKey(variableKey),
+					withValueSecretRef(common.TestCreateLocalSecretKeySelector("something", "blah")),
+					withDeletionTimestamp(),
+					withConditions(xpv1.Deleting()),
+				),
+			},
+			want: want{
+				cr: variable(
+					withGroupID(groupID),
+					withKey(variableKey),
+					withValueSecretRef(common.TestCreateLocalSecretKeySelector("something", "blah")),
+					withDeletionTimestamp(),
+					withConditions(xpv1.Deleting()),
+				),
+				result: managed.ExternalObservation{ResourceExists: true},
 			},
 		},
 	}

--- a/pkg/namespaced/controller/projects/variables/controller.go
+++ b/pkg/namespaced/controller/projects/variables/controller.go
@@ -131,6 +131,11 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.Wrap(err, errGetFailed)
 	}
 
+	// Deleting: only need to determine external resource still exists.
+	if !cr.ObjectMeta.DeletionTimestamp.IsZero() {
+		return managed.ExternalObservation{ResourceExists: true}, nil
+	}
+
 	if cr.Spec.ForProvider.ValueSecretRef != nil {
 		if err = e.updateVariableFromSecret(mg, ctx, cr.Spec.ForProvider.ValueSecretRef, &cr.Spec.ForProvider); err != nil {
 			return managed.ExternalObservation{}, errors.Wrap(err, errUpdateFailed)

--- a/pkg/namespaced/controller/projects/variables/controller_test.go
+++ b/pkg/namespaced/controller/projects/variables/controller_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane-contrib/provider-gitlab/apis/namespaced/projects/v1alpha1"
@@ -130,6 +131,14 @@ func withVariableType(variableType v1alpha1.VariableType) variableModifier {
 func withEnvironmentScope(scope string) variableModifier {
 	return func(r *v1alpha1.Variable) {
 		r.Spec.ForProvider.EnvironmentScope = &scope
+	}
+}
+
+var deletionTime = metav1.Now()
+
+func withDeletionTimestamp() variableModifier {
+	return func(r *v1alpha1.Variable) {
+		r.ObjectMeta.DeletionTimestamp = &deletionTime
 	}
 }
 
@@ -358,6 +367,35 @@ func TestObserve(t *testing.T) {
 					withValueSecretRef(common.TestCreateLocalSecretKeySelector("", "bad")),
 				),
 				err: errors.Wrap(errors.New(common.ErrSecretKeyNotFound), errGetFailed),
+			},
+		},
+		"DeletingEarlyReturnSkipsSecret": {
+			args: args{
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error { return errBoom },
+				},
+				variable: &fake.MockClient{
+					MockGetVariable: func(pid interface{}, key string, opt *gitlab.GetProjectVariableOptions, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectVariable, *gitlab.Response, error) {
+						return &pv, &gitlab.Response{}, nil
+					},
+				},
+				cr: variable(
+					withProjectID(projectID),
+					withKey(variableKey),
+					withValueSecretRef(common.TestCreateLocalSecretKeySelector("", "blah")),
+					withDeletionTimestamp(),
+					withConditions(xpv1.Deleting()),
+				),
+			},
+			want: want{
+				cr: variable(
+					withProjectID(projectID),
+					withKey(variableKey),
+					withValueSecretRef(common.TestCreateLocalSecretKeySelector("", "blah")),
+					withDeletionTimestamp(),
+					withConditions(xpv1.Deleting()),
+				),
+				result: managed.ExternalObservation{ResourceExists: true},
 			},
 		},
 	}


### PR DESCRIPTION
### Description of your changes
Early-return in Variable controllers' Observe when the managed resource is deleting. We only assert external GitLab variable existence and skip fetching the Kubernetes Secret value.

Fixes #230

### How has this code been tested
- Added unit tests `DeletingEarlyReturnSkipsSecret` for each Variable controller (4 total) asserting we short-circuit secret retrieval on deletion.
- Manually verified tests fail if early-return code is removed.