### PR TITLE
fix: use correct property for group accesstoken name

### DIFF
--- a/pkg/cluster/clients/groups/zz_accesstoken.go
+++ b/pkg/cluster/clients/groups/zz_accesstoken.go
@@ -51,7 +51,7 @@ func NewAccessTokenClient(cfg common.Config) AccessTokenClient {
 // GenerateCreateGroupAccessTokenOptions generates project creation options
 func GenerateCreateGroupAccessTokenOptions(name string, p *v1alpha1.AccessTokenParameters) *gitlab.CreateGroupAccessTokenOptions {
 	accesstoken := &gitlab.CreateGroupAccessTokenOptions{
-		Name:   &name,
+		Name:   &p.Name,
 		Scopes: &p.Scopes,
 	}
 

--- a/pkg/cluster/clients/projects/zz_accesstoken.go
+++ b/pkg/cluster/clients/projects/zz_accesstoken.go
@@ -51,7 +51,7 @@ func NewAccessTokenClient(cfg common.Config) AccessTokenClient {
 // GenerateCreateProjectAccessTokenOptions generates project creation options
 func GenerateCreateProjectAccessTokenOptions(name string, p *v1alpha1.AccessTokenParameters) *gitlab.CreateProjectAccessTokenOptions {
 	accesstoken := &gitlab.CreateProjectAccessTokenOptions{
-		Name:   &name,
+		Name:   &p.Name,
 		Scopes: &p.Scopes,
 	}
 

--- a/pkg/cluster/controller/groups/accesstokens/zz_controller_test.go
+++ b/pkg/cluster/controller/groups/accesstokens/zz_controller_test.go
@@ -478,6 +478,7 @@ func TestCreate(t *testing.T) {
 				cr: accessToken(
 					withSpec(v1alpha1.AccessTokenParameters{
 						GroupID: &id,
+						Name:    "Access Token Name",
 					}),
 					withAnnotations(extNameAnnotation),
 				),
@@ -486,6 +487,7 @@ func TestCreate(t *testing.T) {
 				cr: accessToken(
 					withSpec(v1alpha1.AccessTokenParameters{
 						GroupID: &id,
+						Name:    "Access Token Name",
 					}),
 					withExternalName(sAccessTokenID),
 				),

--- a/pkg/cluster/controller/projects/accesstokens/zz_controller_test.go
+++ b/pkg/cluster/controller/projects/accesstokens/zz_controller_test.go
@@ -482,6 +482,7 @@ func TestCreate(t *testing.T) {
 				cr: accessToken(
 					withSpec(v1alpha1.AccessTokenParameters{
 						ProjectID: &projectID,
+						Name:      "Access Token Name",
 					}),
 					withAnnotations(extNameAnnotation),
 				),
@@ -490,6 +491,7 @@ func TestCreate(t *testing.T) {
 				cr: accessToken(
 					withSpec(v1alpha1.AccessTokenParameters{
 						ProjectID: &projectID,
+						Name:      "Access Token Name",
 					}),
 					withExternalName(sAccessTokenID),
 				),

--- a/pkg/namespaced/clients/groups/accesstoken.go
+++ b/pkg/namespaced/clients/groups/accesstoken.go
@@ -49,7 +49,7 @@ func NewAccessTokenClient(cfg common.Config) AccessTokenClient {
 // GenerateCreateGroupAccessTokenOptions generates project creation options
 func GenerateCreateGroupAccessTokenOptions(name string, p *v1alpha1.AccessTokenParameters) *gitlab.CreateGroupAccessTokenOptions {
 	accesstoken := &gitlab.CreateGroupAccessTokenOptions{
-		Name:   &name,
+		Name:   &p.Name,
 		Scopes: &p.Scopes,
 	}
 

--- a/pkg/namespaced/clients/projects/accesstoken.go
+++ b/pkg/namespaced/clients/projects/accesstoken.go
@@ -49,7 +49,7 @@ func NewAccessTokenClient(cfg common.Config) AccessTokenClient {
 // GenerateCreateProjectAccessTokenOptions generates project creation options
 func GenerateCreateProjectAccessTokenOptions(name string, p *v1alpha1.AccessTokenParameters) *gitlab.CreateProjectAccessTokenOptions {
 	accesstoken := &gitlab.CreateProjectAccessTokenOptions{
-		Name:   &name,
+		Name:   &p.Name,
 		Scopes: &p.Scopes,
 	}
 

--- a/pkg/namespaced/controller/groups/accesstokens/controller_test.go
+++ b/pkg/namespaced/controller/groups/accesstokens/controller_test.go
@@ -476,6 +476,7 @@ func TestCreate(t *testing.T) {
 				cr: accessToken(
 					withSpec(v1alpha1.AccessTokenParameters{
 						GroupID: &id,
+						Name:    "Access Token Name",
 					}),
 					withAnnotations(extNameAnnotation),
 				),
@@ -484,6 +485,7 @@ func TestCreate(t *testing.T) {
 				cr: accessToken(
 					withSpec(v1alpha1.AccessTokenParameters{
 						GroupID: &id,
+						Name:    "Access Token Name",
 					}),
 					withExternalName(sAccessTokenID),
 				),

--- a/pkg/namespaced/controller/projects/accesstokens/controller_test.go
+++ b/pkg/namespaced/controller/projects/accesstokens/controller_test.go
@@ -480,6 +480,7 @@ func TestCreate(t *testing.T) {
 				cr: accessToken(
 					withSpec(v1alpha1.AccessTokenParameters{
 						ProjectID: &projectID,
+						Name:      "Access Token Name",
 					}),
 					withAnnotations(extNameAnnotation),
 				),
@@ -488,6 +489,7 @@ func TestCreate(t *testing.T) {
 				cr: accessToken(
 					withSpec(v1alpha1.AccessTokenParameters{
 						ProjectID: &projectID,
+						Name:      "Access Token Name",
 					}),
 					withExternalName(sAccessTokenID),
 				),


### PR DESCRIPTION
### Description of your changes

The `name` property of an group-accesstoken is right now ignored. The `metadata.name` is being used instead. This PR fixes this.

Fixes #191

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I added the change and saw (as expected) that the test for it starts failing. So I adjusted the test to reflect the new change, too.

[contribution process]: https://git.io/fj2m9
