### PR TITLE
fix: intial creation for pushRules

### DIFF
--- a/pkg/cluster/clients/projects/fake/zz_fake.go
+++ b/pkg/cluster/clients/projects/fake/zz_fake.go
@@ -75,6 +75,7 @@ type MockClient struct {
 	MockListUsers func(opt *gitlab.ListUsersOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.User, *gitlab.Response, error)
 
 	MockGetProjectPushRules func(pid any, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectPushRules, *gitlab.Response, error)
+	MockAddProjectPushRule  func(pid any, opt *gitlab.AddProjectPushRuleOptions, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectPushRules, *gitlab.Response, error)
 	MockEditProjectPushRule func(pid any, opt *gitlab.EditProjectPushRuleOptions, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectPushRules, *gitlab.Response, error)
 
 	MockGetProjectApprovalRule    func(pid any, ruleID int, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectApprovalRule, *gitlab.Response, error)
@@ -270,6 +271,11 @@ func (c *MockClient) ListUsers(opt *gitlab.ListUsersOptions, options ...gitlab.R
 // GetProjectPushRules calls the underlying MockGetProjectPushRules method.
 func (c *MockClient) GetProjectPushRules(pid any, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectPushRules, *gitlab.Response, error) {
 	return c.MockGetProjectPushRules(pid, options...)
+}
+
+// AddProjectPushRule calls the underlying MockAddProjectPushRule method.
+func (c *MockClient) AddProjectPushRule(pid any, opt *gitlab.AddProjectPushRuleOptions, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectPushRules, *gitlab.Response, error) {
+	return c.MockAddProjectPushRule(pid, opt, options...)
 }
 
 // EditProjectPushRule calls the underlying MockEditProjectPushRule method.

--- a/pkg/cluster/clients/projects/zz_project.go
+++ b/pkg/cluster/clients/projects/zz_project.go
@@ -42,6 +42,7 @@ type Client interface {
 	DeleteProject(pid interface{}, opt *gitlab.DeleteProjectOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Response, error)
 
 	GetProjectPushRules(pid interface{}, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectPushRules, *gitlab.Response, error)
+	AddProjectPushRule(pid interface{}, opt *gitlab.AddProjectPushRuleOptions, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectPushRules, *gitlab.Response, error)
 	EditProjectPushRule(pid interface{}, opt *gitlab.EditProjectPushRuleOptions, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectPushRules, *gitlab.Response, error)
 }
 
@@ -419,6 +420,26 @@ func GenerateEditProjectOptions(name string, p *v1alpha1.ProjectParameters) *git
 		SuggestionCommitMessage:                  p.SuggestionCommitMessage,
 		IssuesTemplate:                           p.IssuesTemplate,
 		MergeRequestsTemplate:                    p.MergeRequestsTemplate,
+	}
+	return o
+}
+
+func GenerateAddPushRulesOptions(p *v1alpha1.ProjectParameters) *gitlab.AddProjectPushRuleOptions {
+	o := &gitlab.AddProjectPushRuleOptions{}
+	if p.PushRules != nil {
+		o.AuthorEmailRegex = p.PushRules.AuthorEmailRegex
+		o.BranchNameRegex = p.PushRules.BranchNameRegex
+		o.CommitCommitterCheck = p.PushRules.CommitCommitterCheck
+		o.CommitCommitterNameCheck = p.PushRules.CommitCommitterNameCheck
+		o.CommitMessageNegativeRegex = p.PushRules.CommitMessageNegativeRegex
+		o.CommitMessageRegex = p.PushRules.CommitMessageRegex
+		o.DenyDeleteTag = p.PushRules.DenyDeleteTag
+		o.FileNameRegex = p.PushRules.FileNameRegex
+		o.MaxFileSize = p.PushRules.MaxFileSize
+		o.MemberCheck = p.PushRules.MemberCheck
+		o.PreventSecrets = p.PushRules.PreventSecrets
+		o.RejectNonDCOCommits = p.PushRules.RejectNonDCOCommits
+		o.RejectUnsignedCommits = p.PushRules.RejectUnsignedCommits
 	}
 	return o
 }

--- a/pkg/cluster/controller/projects/projects/zz_project.go
+++ b/pkg/cluster/controller/projects/projects/zz_project.go
@@ -225,13 +225,26 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		// Only attempt to update push rules if the feature is supported
 		// (either we have cached rules or push rules are specified in spec)
 		if e.cache.externalPushRules != nil || cr.Spec.ForProvider.PushRules != nil {
-			_, _, err := e.client.EditProjectPushRule(
-				meta.GetExternalName(cr),
-				projects.GenerateEditPushRulesOptions(&cr.Spec.ForProvider),
-				gitlab.WithContext(ctx),
-			)
-			if err != nil {
-				return managed.ExternalUpdate{}, errors.Wrap(err, errUpdatePushRulesFailed)
+			if e.cache.externalPushRules != nil {
+				// Push rules exist in GitLab → Edit (PUT)
+				_, _, err := e.client.EditProjectPushRule(
+					meta.GetExternalName(cr),
+					projects.GenerateEditPushRulesOptions(&cr.Spec.ForProvider),
+					gitlab.WithContext(ctx),
+				)
+				if err != nil {
+					return managed.ExternalUpdate{}, errors.Wrap(err, errUpdatePushRulesFailed)
+				}
+			} else {
+				// Push rules don't exist yet in GitLab → Add (POST)
+				_, _, err := e.client.AddProjectPushRule(
+					meta.GetExternalName(cr),
+					projects.GenerateAddPushRulesOptions(&cr.Spec.ForProvider),
+					gitlab.WithContext(ctx),
+				)
+				if err != nil {
+					return managed.ExternalUpdate{}, errors.Wrap(err, errUpdatePushRulesFailed)
+				}
 			}
 		}
 		// If push rules are not supported (e.g., GitLab Community Edition) and
@@ -447,6 +460,12 @@ func (e *external) getProjectPushRules(ctx context.Context, cr *v1alpha1.Project
 			return nil, nil
 		}
 		return nil, errors.Wrap(err, errGetPushRulesFailed)
+	}
+	// GitLab Premium/Enterprise may return 200 with null body when no push rules
+	// are configured for the project. In that case res is nil — treat it the same
+	// as "no push rules exist yet".
+	if res == nil {
+		return nil, nil
 	}
 	e.cache.externalPushRules = &v1alpha1.PushRules{
 		AuthorEmailRegex:           &res.AuthorEmailRegex,

--- a/pkg/namespaced/clients/projects/fake/fake.go
+++ b/pkg/namespaced/clients/projects/fake/fake.go
@@ -73,6 +73,7 @@ type MockClient struct {
 	MockListUsers func(opt *gitlab.ListUsersOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.User, *gitlab.Response, error)
 
 	MockGetProjectPushRules func(pid any, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectPushRules, *gitlab.Response, error)
+	MockAddProjectPushRule  func(pid any, opt *gitlab.AddProjectPushRuleOptions, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectPushRules, *gitlab.Response, error)
 	MockEditProjectPushRule func(pid any, opt *gitlab.EditProjectPushRuleOptions, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectPushRules, *gitlab.Response, error)
 
 	MockGetProjectApprovalRule    func(pid any, ruleID int, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectApprovalRule, *gitlab.Response, error)
@@ -268,6 +269,11 @@ func (c *MockClient) ListUsers(opt *gitlab.ListUsersOptions, options ...gitlab.R
 // GetProjectPushRules calls the underlying MockGetProjectPushRules method.
 func (c *MockClient) GetProjectPushRules(pid any, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectPushRules, *gitlab.Response, error) {
 	return c.MockGetProjectPushRules(pid, options...)
+}
+
+// AddProjectPushRule calls the underlying MockAddProjectPushRule method.
+func (c *MockClient) AddProjectPushRule(pid any, opt *gitlab.AddProjectPushRuleOptions, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectPushRules, *gitlab.Response, error) {
+	return c.MockAddProjectPushRule(pid, opt, options...)
 }
 
 // EditProjectPushRule calls the underlying MockEditProjectPushRule method.

--- a/pkg/namespaced/clients/projects/project.go
+++ b/pkg/namespaced/clients/projects/project.go
@@ -40,6 +40,7 @@ type Client interface {
 	DeleteProject(pid interface{}, opt *gitlab.DeleteProjectOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Response, error)
 
 	GetProjectPushRules(pid interface{}, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectPushRules, *gitlab.Response, error)
+	AddProjectPushRule(pid interface{}, opt *gitlab.AddProjectPushRuleOptions, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectPushRules, *gitlab.Response, error)
 	EditProjectPushRule(pid interface{}, opt *gitlab.EditProjectPushRuleOptions, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectPushRules, *gitlab.Response, error)
 }
 
@@ -417,6 +418,26 @@ func GenerateEditProjectOptions(name string, p *v1alpha1.ProjectParameters) *git
 		SuggestionCommitMessage:                  p.SuggestionCommitMessage,
 		IssuesTemplate:                           p.IssuesTemplate,
 		MergeRequestsTemplate:                    p.MergeRequestsTemplate,
+	}
+	return o
+}
+
+func GenerateAddPushRulesOptions(p *v1alpha1.ProjectParameters) *gitlab.AddProjectPushRuleOptions {
+	o := &gitlab.AddProjectPushRuleOptions{}
+	if p.PushRules != nil {
+		o.AuthorEmailRegex = p.PushRules.AuthorEmailRegex
+		o.BranchNameRegex = p.PushRules.BranchNameRegex
+		o.CommitCommitterCheck = p.PushRules.CommitCommitterCheck
+		o.CommitCommitterNameCheck = p.PushRules.CommitCommitterNameCheck
+		o.CommitMessageNegativeRegex = p.PushRules.CommitMessageNegativeRegex
+		o.CommitMessageRegex = p.PushRules.CommitMessageRegex
+		o.DenyDeleteTag = p.PushRules.DenyDeleteTag
+		o.FileNameRegex = p.PushRules.FileNameRegex
+		o.MaxFileSize = p.PushRules.MaxFileSize
+		o.MemberCheck = p.PushRules.MemberCheck
+		o.PreventSecrets = p.PushRules.PreventSecrets
+		o.RejectNonDCOCommits = p.PushRules.RejectNonDCOCommits
+		o.RejectUnsignedCommits = p.PushRules.RejectUnsignedCommits
 	}
 	return o
 }

--- a/pkg/namespaced/controller/projects/projects/project.go
+++ b/pkg/namespaced/controller/projects/projects/project.go
@@ -223,13 +223,26 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		// Only attempt to update push rules if the feature is supported
 		// (either we have cached rules or push rules are specified in spec)
 		if e.cache.externalPushRules != nil || cr.Spec.ForProvider.PushRules != nil {
-			_, _, err := e.client.EditProjectPushRule(
-				meta.GetExternalName(cr),
-				projects.GenerateEditPushRulesOptions(&cr.Spec.ForProvider),
-				gitlab.WithContext(ctx),
-			)
-			if err != nil {
-				return managed.ExternalUpdate{}, errors.Wrap(err, errUpdatePushRulesFailed)
+			if e.cache.externalPushRules != nil {
+				// Push rules exist in GitLab → Edit (PUT)
+				_, _, err := e.client.EditProjectPushRule(
+					meta.GetExternalName(cr),
+					projects.GenerateEditPushRulesOptions(&cr.Spec.ForProvider),
+					gitlab.WithContext(ctx),
+				)
+				if err != nil {
+					return managed.ExternalUpdate{}, errors.Wrap(err, errUpdatePushRulesFailed)
+				}
+			} else {
+				// Push rules don't exist yet in GitLab → Add (POST)
+				_, _, err := e.client.AddProjectPushRule(
+					meta.GetExternalName(cr),
+					projects.GenerateAddPushRulesOptions(&cr.Spec.ForProvider),
+					gitlab.WithContext(ctx),
+				)
+				if err != nil {
+					return managed.ExternalUpdate{}, errors.Wrap(err, errUpdatePushRulesFailed)
+				}
 			}
 		}
 		// If push rules are not supported (e.g., GitLab Community Edition) and
@@ -445,6 +458,12 @@ func (e *external) getProjectPushRules(ctx context.Context, cr *v1alpha1.Project
 			return nil, nil
 		}
 		return nil, errors.Wrap(err, errGetPushRulesFailed)
+	}
+	// GitLab Premium/Enterprise may return 200 with null body when no push rules
+	// are configured for the project. In that case res is nil — treat it the same
+	// as "no push rules exist yet".
+	if res == nil {
+		return nil, nil
 	}
 	e.cache.externalPushRules = &v1alpha1.PushRules{
 		AuthorEmailRegex:           &res.AuthorEmailRegex,


### PR DESCRIPTION
### Description of your changes

When a GitLab project has no push rules configured, the provider fails with `cannot update Gitlab project push rules: 404 Not Found` because it only uses `EditProjectPushRule` (PUT). The GitLab API requires a POST (`AddProjectPushRule`) to create the initial push rule record before PUT can be used for updates.

This PR fixes two bugs:

1. **Missing `AddProjectPushRule` (POST):** Added `AddProjectPushRule` to the client interface and `GenerateAddPushRulesOptions` helper. The controller's `Update` method now checks `externalPushRules`: if non-nil (rules exist), it uses PUT (Edit); if nil (no rules yet), it uses POST (Add).

2. **Nil pointer panic on null GET response:** On GitLab Premium/Enterprise, `GET /projects/:id/push_rule` can return `200` with a `null` body when no push rules exist. The provider did not handle this case and would panic dereferencing nil fields. Added a `res == nil` check in `getProjectPushRules` to treat this as "no push rules configured".

Changes apply to both namespaced and cluster-scoped controllers (cluster-scoped files are auto-generated from namespaced sources).

Fixes #280

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- Verified via curl against a GitLab Premium instance (project 434968) that:
  - `GET /push_rule` returns `200` with `null` body (no push rules configured)
  - `PUT /push_rule` returns `404 Push rule Not Found`
  - `POST /push_rule` returns `201 Created` and creates the push rules
  - After POST, `PUT /push_rule` returns `200` and works correctly
- Existing unit tests pass (`TestObserve`, `TestUpdate`, `TestCreate`, `TestDelete`)

[contribution process]: https://git.io/fj2m9