### PR TITLE
fix: check also on res.ID = 0

### DIFF
--- a/pkg/cluster/controller/projects/projects/zz_project.go
+++ b/pkg/cluster/controller/projects/projects/zz_project.go
@@ -222,35 +222,34 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 
 	if !e.cache.isPushRulesUpToDate {
-		// Only attempt to update push rules if the feature is supported
-		// (either we have cached rules or push rules are specified in spec)
-		if e.cache.externalPushRules != nil || cr.Spec.ForProvider.PushRules != nil {
-			if e.cache.externalPushRules != nil {
-				// Push rules exist in GitLab → Edit (PUT)
-				_, _, err := e.client.EditProjectPushRule(
-					meta.GetExternalName(cr),
-					projects.GenerateEditPushRulesOptions(&cr.Spec.ForProvider),
-					gitlab.WithContext(ctx),
-				)
-				if err != nil {
-					return managed.ExternalUpdate{}, errors.Wrap(err, errUpdatePushRulesFailed)
-				}
-			} else {
-				// Push rules don't exist yet in GitLab → Add (POST)
-				_, _, err := e.client.AddProjectPushRule(
-					meta.GetExternalName(cr),
-					projects.GenerateAddPushRulesOptions(&cr.Spec.ForProvider),
-					gitlab.WithContext(ctx),
-				)
-				if err != nil {
-					return managed.ExternalUpdate{}, errors.Wrap(err, errUpdatePushRulesFailed)
-				}
-			}
+		if err := e.updatePushRules(ctx, cr); err != nil {
+			return managed.ExternalUpdate{}, err
 		}
-		// If push rules are not supported (e.g., GitLab Community Edition) and
-		// none are specified in spec, we skip updating them
 	}
 	return managed.ExternalUpdate{}, nil
+}
+
+// updatePushRules reconciles push rules for a project. It decides whether to
+// add (POST) or edit (PUT) push rules based on whether they already exist in
+// GitLab (cached in e.cache.externalPushRules). If neither cached rules nor
+// spec push rules exist, the call is a no-op (e.g., GitLab Community Edition
+// where push rules are not supported and none are specified).
+func (e *external) updatePushRules(ctx context.Context, cr *v1alpha1.Project) error {
+	if e.cache.externalPushRules == nil && cr.Spec.ForProvider.PushRules == nil {
+		return nil
+	}
+
+	pid := meta.GetExternalName(cr)
+
+	// Push rules already exist in GitLab → Edit (PUT)
+	if e.cache.externalPushRules != nil {
+		_, _, err := e.client.EditProjectPushRule(pid, projects.GenerateEditPushRulesOptions(&cr.Spec.ForProvider), gitlab.WithContext(ctx))
+		return errors.Wrap(err, errUpdatePushRulesFailed)
+	}
+
+	// Push rules don't exist yet in GitLab → Add (POST)
+	_, _, err := e.client.AddProjectPushRule(pid, projects.GenerateAddPushRulesOptions(&cr.Spec.ForProvider), gitlab.WithContext(ctx))
+	return errors.Wrap(err, errUpdatePushRulesFailed)
 }
 
 func (e *external) Delete(ctx context.Context, mg resource.Managed) (managed.ExternalDelete, error) {

--- a/pkg/cluster/controller/projects/projects/zz_project_test.go
+++ b/pkg/cluster/controller/projects/projects/zz_project_test.go
@@ -352,6 +352,7 @@ func TestObserve(t *testing.T) {
 					MockGetProjectPushRules: func(pid interface{}, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectPushRules, *gitlab.Response, error) {
 						// Simulate GitLab where push rules are configured but removed from spec
 						return &gitlab.ProjectPushRules{
+							ID:                         1,
 							AuthorEmailRegex:           ".*@company.com",
 							BranchNameRegex:            "^(feature|hotfix)/.*",
 							CommitCommitterCheck:       true,
@@ -396,7 +397,7 @@ func TestObserve(t *testing.T) {
 						return &gitlab.Project{Name: "example-project"}, &gitlab.Response{}, nil
 					},
 					MockGetProjectPushRules: func(pid interface{}, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectPushRules, *gitlab.Response, error) {
-						return &gitlab.ProjectPushRules{}, nil, nil
+						return &gitlab.ProjectPushRules{ID: 1}, nil, nil
 					},
 				},
 				cr: project(
@@ -493,7 +494,7 @@ func TestObserve(t *testing.T) {
 						return &gitlab.Project{MirrorUserID: 0}, &gitlab.Response{}, nil
 					},
 					MockGetProjectPushRules: func(pid interface{}, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectPushRules, *gitlab.Response, error) {
-						return &gitlab.ProjectPushRules{}, nil, nil
+						return &gitlab.ProjectPushRules{ID: 1}, nil, nil
 					},
 				},
 				cr: project(
@@ -816,6 +817,7 @@ func TestObserve(t *testing.T) {
 					},
 					MockGetProjectPushRules: func(pid interface{}, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectPushRules, *gitlab.Response, error) {
 						return &gitlab.ProjectPushRules{
+							ID:            1,
 							DenyDeleteTag: true,
 						}, nil, nil
 					},
@@ -932,6 +934,8 @@ func TestUpdate(t *testing.T) {
 
 	cases := map[string]struct {
 		args
+		cacheExternalPushRules *v1alpha1.PushRules
+		cachePushRulesUpToDate bool
 		want
 	}{
 		"InValidInput": {
@@ -976,10 +980,132 @@ func TestUpdate(t *testing.T) {
 				err: errors.Wrap(errBoom, errUpdateFailed),
 			},
 		},
+		"SuccessfulEditPushRules": {
+			args: args{
+				project: &fake.MockClient{
+					MockEditProject: func(pid interface{}, opt *gitlab.EditProjectOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Project, *gitlab.Response, error) {
+						return &gitlab.Project{}, &gitlab.Response{}, nil
+					},
+					MockEditProjectPushRule: func(pid interface{}, opt *gitlab.EditProjectPushRuleOptions, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectPushRules, *gitlab.Response, error) {
+						return &gitlab.ProjectPushRules{}, &gitlab.Response{}, nil
+					},
+				},
+				cr: project(
+					withStatus(v1alpha1.ProjectObservation{ID: 1234}),
+					withProjectPushRules(&v1alpha1.PushRules{DenyDeleteTag: ptr.To(true)}),
+				),
+			},
+			cacheExternalPushRules: &v1alpha1.PushRules{DenyDeleteTag: ptr.To(false)},
+			cachePushRulesUpToDate: false,
+			want: want{
+				cr: project(
+					withStatus(v1alpha1.ProjectObservation{ID: 1234}),
+					withProjectPushRules(&v1alpha1.PushRules{DenyDeleteTag: ptr.To(true)}),
+				),
+			},
+		},
+		"SuccessfulAddPushRules": {
+			args: args{
+				project: &fake.MockClient{
+					MockEditProject: func(pid interface{}, opt *gitlab.EditProjectOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Project, *gitlab.Response, error) {
+						return &gitlab.Project{}, &gitlab.Response{}, nil
+					},
+					MockAddProjectPushRule: func(pid interface{}, opt *gitlab.AddProjectPushRuleOptions, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectPushRules, *gitlab.Response, error) {
+						return &gitlab.ProjectPushRules{}, &gitlab.Response{}, nil
+					},
+				},
+				cr: project(
+					withStatus(v1alpha1.ProjectObservation{ID: 1234}),
+					withProjectPushRules(&v1alpha1.PushRules{DenyDeleteTag: ptr.To(true)}),
+				),
+			},
+			cacheExternalPushRules: nil,
+			cachePushRulesUpToDate: false,
+			want: want{
+				cr: project(
+					withStatus(v1alpha1.ProjectObservation{ID: 1234}),
+					withProjectPushRules(&v1alpha1.PushRules{DenyDeleteTag: ptr.To(true)}),
+				),
+			},
+		},
+		"FailedEditPushRules": {
+			args: args{
+				project: &fake.MockClient{
+					MockEditProject: func(pid interface{}, opt *gitlab.EditProjectOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Project, *gitlab.Response, error) {
+						return &gitlab.Project{}, &gitlab.Response{}, nil
+					},
+					MockEditProjectPushRule: func(pid interface{}, opt *gitlab.EditProjectPushRuleOptions, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectPushRules, *gitlab.Response, error) {
+						return &gitlab.ProjectPushRules{}, &gitlab.Response{}, errBoom
+					},
+				},
+				cr: project(
+					withStatus(v1alpha1.ProjectObservation{ID: 1234}),
+					withProjectPushRules(&v1alpha1.PushRules{DenyDeleteTag: ptr.To(true)}),
+				),
+			},
+			cacheExternalPushRules: &v1alpha1.PushRules{DenyDeleteTag: ptr.To(false)},
+			cachePushRulesUpToDate: false,
+			want: want{
+				cr: project(
+					withStatus(v1alpha1.ProjectObservation{ID: 1234}),
+					withProjectPushRules(&v1alpha1.PushRules{DenyDeleteTag: ptr.To(true)}),
+				),
+				err: errors.Wrap(errBoom, errUpdatePushRulesFailed),
+			},
+		},
+		"FailedAddPushRules": {
+			args: args{
+				project: &fake.MockClient{
+					MockEditProject: func(pid interface{}, opt *gitlab.EditProjectOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Project, *gitlab.Response, error) {
+						return &gitlab.Project{}, &gitlab.Response{}, nil
+					},
+					MockAddProjectPushRule: func(pid interface{}, opt *gitlab.AddProjectPushRuleOptions, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectPushRules, *gitlab.Response, error) {
+						return &gitlab.ProjectPushRules{}, &gitlab.Response{}, errBoom
+					},
+				},
+				cr: project(
+					withStatus(v1alpha1.ProjectObservation{ID: 1234}),
+					withProjectPushRules(&v1alpha1.PushRules{DenyDeleteTag: ptr.To(true)}),
+				),
+			},
+			cacheExternalPushRules: nil,
+			cachePushRulesUpToDate: false,
+			want: want{
+				cr: project(
+					withStatus(v1alpha1.ProjectObservation{ID: 1234}),
+					withProjectPushRules(&v1alpha1.PushRules{DenyDeleteTag: ptr.To(true)}),
+				),
+				err: errors.Wrap(errBoom, errUpdatePushRulesFailed),
+			},
+		},
+		"PushRulesUpToDateSkipped": {
+			args: args{
+				project: &fake.MockClient{
+					MockEditProject: func(pid interface{}, opt *gitlab.EditProjectOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Project, *gitlab.Response, error) {
+						return &gitlab.Project{}, &gitlab.Response{}, nil
+					},
+					// No push rule mocks needed - they should not be called
+				},
+				cr: project(
+					withStatus(v1alpha1.ProjectObservation{ID: 1234}),
+					withProjectPushRules(&v1alpha1.PushRules{DenyDeleteTag: ptr.To(true)}),
+				),
+			},
+			cacheExternalPushRules: &v1alpha1.PushRules{DenyDeleteTag: ptr.To(true)},
+			cachePushRulesUpToDate: true,
+			want: want{
+				cr: project(
+					withStatus(v1alpha1.ProjectObservation{ID: 1234}),
+					withProjectPushRules(&v1alpha1.PushRules{DenyDeleteTag: ptr.To(true)}),
+				),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			e := &external{kube: tc.kube, client: tc.project}
+			e.cache.externalPushRules = tc.cacheExternalPushRules
+			e.cache.isPushRulesUpToDate = tc.cachePushRulesUpToDate
 			o, err := e.Update(context.Background(), tc.args.cr)
 
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {

--- a/pkg/namespaced/controller/projects/projects/project.go
+++ b/pkg/namespaced/controller/projects/projects/project.go
@@ -220,35 +220,34 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 
 	if !e.cache.isPushRulesUpToDate {
-		// Only attempt to update push rules if the feature is supported
-		// (either we have cached rules or push rules are specified in spec)
-		if e.cache.externalPushRules != nil || cr.Spec.ForProvider.PushRules != nil {
-			if e.cache.externalPushRules != nil {
-				// Push rules exist in GitLab → Edit (PUT)
-				_, _, err := e.client.EditProjectPushRule(
-					meta.GetExternalName(cr),
-					projects.GenerateEditPushRulesOptions(&cr.Spec.ForProvider),
-					gitlab.WithContext(ctx),
-				)
-				if err != nil {
-					return managed.ExternalUpdate{}, errors.Wrap(err, errUpdatePushRulesFailed)
-				}
-			} else {
-				// Push rules don't exist yet in GitLab → Add (POST)
-				_, _, err := e.client.AddProjectPushRule(
-					meta.GetExternalName(cr),
-					projects.GenerateAddPushRulesOptions(&cr.Spec.ForProvider),
-					gitlab.WithContext(ctx),
-				)
-				if err != nil {
-					return managed.ExternalUpdate{}, errors.Wrap(err, errUpdatePushRulesFailed)
-				}
-			}
+		if err := e.updatePushRules(ctx, cr); err != nil {
+			return managed.ExternalUpdate{}, err
 		}
-		// If push rules are not supported (e.g., GitLab Community Edition) and
-		// none are specified in spec, we skip updating them
 	}
 	return managed.ExternalUpdate{}, nil
+}
+
+// updatePushRules reconciles push rules for a project. It decides whether to
+// add (POST) or edit (PUT) push rules based on whether they already exist in
+// GitLab (cached in e.cache.externalPushRules). If neither cached rules nor
+// spec push rules exist, the call is a no-op (e.g., GitLab Community Edition
+// where push rules are not supported and none are specified).
+func (e *external) updatePushRules(ctx context.Context, cr *v1alpha1.Project) error {
+	if e.cache.externalPushRules == nil && cr.Spec.ForProvider.PushRules == nil {
+		return nil
+	}
+
+	pid := meta.GetExternalName(cr)
+
+	// Push rules already exist in GitLab → Edit (PUT)
+	if e.cache.externalPushRules != nil {
+		_, _, err := e.client.EditProjectPushRule(pid, projects.GenerateEditPushRulesOptions(&cr.Spec.ForProvider), gitlab.WithContext(ctx))
+		return errors.Wrap(err, errUpdatePushRulesFailed)
+	}
+
+	// Push rules don't exist yet in GitLab → Add (POST)
+	_, _, err := e.client.AddProjectPushRule(pid, projects.GenerateAddPushRulesOptions(&cr.Spec.ForProvider), gitlab.WithContext(ctx))
+	return errors.Wrap(err, errUpdatePushRulesFailed)
 }
 
 func (e *external) Delete(ctx context.Context, mg resource.Managed) (managed.ExternalDelete, error) {


### PR DESCRIPTION
### Description of your changes

Fixes the remaining push rules 404 error that was not fully resolved by #281.

**Root cause:** When a project has no project-level push rules, the GitLab API returns HTTP 200 with a `null` JSON body for `GET /projects/:id/push_rule`. The go-gitlab client allocates the response struct via `new(ProjectPushRules)` before decoding, so JSON `null` leaves a zero-valued struct (non-nil pointer with `ID == 0`) rather than a Go `nil`.

Our previous check `if res == nil` never triggered, causing the controller to cache a zero-valued `PushRules` struct as if real push rules existed. During `Update`, this meant the controller took the Edit (PUT) path instead of the Add (POST) path, and `PUT /projects/:id/push_rule` returns 404 when no project-level push rules exist.

**Fix:** Extend the nil check to `if res == nil || res.ID == 0` in `getProjectPushRules`. A valid push rule always has a non-zero `ID`, so `ID == 0` reliably detects the deserialized `null` response. With the cache no longer incorrectly populated, the existing Edit/Add branching in `Update` works correctly — `e.cache.externalPushRules` stays `nil`, so the controller takes the Add (POST) path as intended.

**Verified against live GitLab API** (`git-test.tech.rz.db.de`, project 435139):
- `GET /push_rule` → 200, body: `null`
- `PUT /push_rule` → 404 (confirms the bug)
- `POST /push_rule` → 201 (confirms the fix path works)

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- Verified the GitLab API behavior with curl against a live instance (GET returns `null`/200, PUT returns 404, POST returns 201)
- Built and pushed the image for manual testing on a cluster

[contribution process]: https://git.io/fj2m9