### PR TITLE
fix: bump Go to 1.25.9 to address stdlib CVEs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: "1.25.8"
+  GO_VERSION: "1.25.9"
   GOLANGCI_VERSION: "v2.11.2"
   DOCKER_BUILDX_VERSION: "v0.21.2"
 

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -13,7 +13,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.23.8'
+  GO_VERSION: '1.25.9'
 
   # Common users. We can't run a step 'if secrets.AWS_USR != ""' but we can run
   # a step 'if env.AWS_USR' != ""', so we copy these to succinctly test whether

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane-contrib/provider-gitlab
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/crossplane/crossplane-runtime/v2 v2.1.0


### PR DESCRIPTION
## Why

Several stdlib CVEs were disclosed affecting Go 1.25.8. Bumping to 1.25.9 addresses all of them and aligns all CI workflows to the same version.

## Changes

- Bump Go from 1.25.8 to 1.25.9 in `go.mod` and CI workflows
- Align `promote.yaml` which was still on the stale 1.23.8
- `grpc` was already at v1.79.3 - no change needed

## CVEs Fixed

- CVE-2026-32280
- CVE-2026-27140
- CVE-2026-32289
- CVE-2026-32282
- CVE-2026-32283
- CVE-2026-32281
- CVE-2026-32288

Follows the same approach as #291.