### PR TITLE
fix: reconcile webhook token rotation for group and project Hook

### DIFF
--- a/apis/cluster/groups/v1alpha1/zz_hook_types.go
+++ b/apis/cluster/groups/v1alpha1/zz_hook_types.go
@@ -133,6 +133,13 @@ type HookObservation struct {
 
 	// CreatedAt specifies the time the group hook was created
 	CreatedAt *metav1.Time `json:"createdAt,omitempty"`
+
+	// TokenHash is a SHA-256 digest of the secret token last pushed to GitLab.
+	// GitLab never returns the token, so this fingerprint is used to detect
+	// rotation of the referenced secret and trigger an update. It is never the
+	// raw token.
+	// +optional
+	TokenHash string `json:"tokenHash,omitempty"`
 }
 
 // A HookSpec defines the desired state of a Gitlab Group Hook.

--- a/apis/cluster/projects/v1alpha1/zz_hook_types.go
+++ b/apis/cluster/projects/v1alpha1/zz_hook_types.go
@@ -35,6 +35,7 @@ type HookParameters struct {
 	// ProjectID is the ID of the project.
 	// +optional
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="projectId is immutable"
 	ProjectID *int64 `json:"projectId,omitempty"`
 
 	// ProjectIDRef is a reference to a project to retrieve its projectId
@@ -108,6 +109,13 @@ type HookObservation struct {
 
 	// CreatedAt specifies the time the project hook was created
 	CreatedAt *metav1.Time `json:"createdAt,omitempty"`
+
+	// TokenHash is a SHA-256 digest of the secret token last pushed to GitLab.
+	// GitLab never returns the token, so this fingerprint is used to detect
+	// rotation of the referenced secret and trigger an update. It is never the
+	// raw token.
+	// +optional
+	TokenHash string `json:"tokenHash,omitempty"`
 }
 
 // A HookSpec defines the desired state of a Gitlab Project Hook.

--- a/apis/namespaced/groups/v1alpha1/hook_types.go
+++ b/apis/namespaced/groups/v1alpha1/hook_types.go
@@ -131,6 +131,13 @@ type HookObservation struct {
 
 	// CreatedAt specifies the time the group hook was created
 	CreatedAt *metav1.Time `json:"createdAt,omitempty"`
+
+	// TokenHash is a SHA-256 digest of the secret token last pushed to GitLab.
+	// GitLab never returns the token, so this fingerprint is used to detect
+	// rotation of the referenced secret and trigger an update. It is never the
+	// raw token.
+	// +optional
+	TokenHash string `json:"tokenHash,omitempty"`
 }
 
 // A HookSpec defines the desired state of a Gitlab Group Hook.

--- a/apis/namespaced/projects/v1alpha1/hook_types.go
+++ b/apis/namespaced/projects/v1alpha1/hook_types.go
@@ -33,6 +33,7 @@ type HookParameters struct {
 	// ProjectID is the ID of the project.
 	// +optional
 	// +immutable
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="projectId is immutable"
 	ProjectID *int64 `json:"projectId,omitempty"`
 
 	// ProjectIDRef is a reference to a project to retrieve its projectId
@@ -106,6 +107,13 @@ type HookObservation struct {
 
 	// CreatedAt specifies the time the project hook was created
 	CreatedAt *metav1.Time `json:"createdAt,omitempty"`
+
+	// TokenHash is a SHA-256 digest of the secret token last pushed to GitLab.
+	// GitLab never returns the token, so this fingerprint is used to detect
+	// rotation of the referenced secret and trigger an update. It is never the
+	// raw token.
+	// +optional
+	TokenHash string `json:"tokenHash,omitempty"`
 }
 
 // A HookSpec defines the desired state of a Gitlab Project Hook.

--- a/package/crds/groups.gitlab.crossplane.io_hooks.yaml
+++ b/package/crds/groups.gitlab.crossplane.io_hooks.yaml
@@ -351,6 +351,13 @@ spec:
                     description: ID of the group hook at gitlab
                     format: int64
                     type: integer
+                  tokenHash:
+                    description: |-
+                      TokenHash is a SHA-256 digest of the secret token last pushed to GitLab.
+                      GitLab never returns the token, so this fingerprint is used to detect
+                      rotation of the referenced secret and trigger an update. It is never the
+                      raw token.
+                    type: string
                 type: object
               conditions:
                 description: Conditions of the resource.

--- a/package/crds/groups.gitlab.m.crossplane.io_hooks.yaml
+++ b/package/crds/groups.gitlab.m.crossplane.io_hooks.yaml
@@ -311,6 +311,13 @@ spec:
                     description: ID of the group hook at gitlab
                     format: int64
                     type: integer
+                  tokenHash:
+                    description: |-
+                      TokenHash is a SHA-256 digest of the secret token last pushed to GitLab.
+                      GitLab never returns the token, so this fingerprint is used to detect
+                      rotation of the referenced secret and trigger an update. It is never the
+                      raw token.
+                    type: string
                 type: object
               conditions:
                 description: Conditions of the resource.

--- a/package/crds/projects.gitlab.crossplane.io_hooks.yaml
+++ b/package/crds/projects.gitlab.crossplane.io_hooks.yaml
@@ -105,6 +105,9 @@ spec:
                     description: ProjectID is the ID of the project.
                     format: int64
                     type: integer
+                    x-kubernetes-validations:
+                    - message: projectId is immutable
+                      rule: self == oldSelf
                   projectIdRef:
                     description: ProjectIDRef is a reference to a project to retrieve
                       its projectId
@@ -331,6 +334,13 @@ spec:
                     description: ID of the project hook at gitlab
                     format: int64
                     type: integer
+                  tokenHash:
+                    description: |-
+                      TokenHash is a SHA-256 digest of the secret token last pushed to GitLab.
+                      GitLab never returns the token, so this fingerprint is used to detect
+                      rotation of the referenced secret and trigger an update. It is never the
+                      raw token.
+                    type: string
                 type: object
               conditions:
                 description: Conditions of the resource.

--- a/package/crds/projects.gitlab.m.crossplane.io_hooks.yaml
+++ b/package/crds/projects.gitlab.m.crossplane.io_hooks.yaml
@@ -91,6 +91,9 @@ spec:
                     description: ProjectID is the ID of the project.
                     format: int64
                     type: integer
+                    x-kubernetes-validations:
+                    - message: projectId is immutable
+                      rule: self == oldSelf
                   projectIdRef:
                     description: ProjectIDRef is a reference to a project to retrieve
                       its projectId
@@ -291,6 +294,13 @@ spec:
                     description: ID of the project hook at gitlab
                     format: int64
                     type: integer
+                  tokenHash:
+                    description: |-
+                      TokenHash is a SHA-256 digest of the secret token last pushed to GitLab.
+                      GitLab never returns the token, so this fingerprint is used to detect
+                      rotation of the referenced secret and trigger an update. It is never the
+                      raw token.
+                    type: string
                 type: object
               conditions:
                 description: Conditions of the resource.

--- a/pkg/cluster/clients/projects/zz_hook.go
+++ b/pkg/cluster/clients/projects/zz_hook.go
@@ -19,8 +19,6 @@ limitations under the License.
 package projects
 
 import (
-	"strings"
-
 	"github.com/google/go-cmp/cmp"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,10 +26,6 @@ import (
 	"github.com/crossplane-contrib/provider-gitlab/apis/cluster/projects/v1alpha1"
 	"github.com/crossplane-contrib/provider-gitlab/pkg/cluster/clients"
 	"github.com/crossplane-contrib/provider-gitlab/pkg/common"
-)
-
-const (
-	errHookNotFound = "404 Not found"
 )
 
 // HookClient defines Gitlab Hook service operations
@@ -46,14 +40,6 @@ type HookClient interface {
 func NewHookClient(cfg common.Config) HookClient {
 	git := common.NewClient(cfg)
 	return git.Projects
-}
-
-// IsErrorHookNotFound helper function to test for errProjectNotFound error.
-func IsErrorHookNotFound(err error) bool {
-	if err == nil {
-		return false
-	}
-	return strings.Contains(err.Error(), errHookNotFound)
 }
 
 // LateInitializeHook fills the empty fields in the hook spec with the

--- a/pkg/cluster/clients/zz_gitlab.go
+++ b/pkg/cluster/clients/zz_gitlab.go
@@ -19,6 +19,8 @@ limitations under the License.
 package clients
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -246,4 +248,17 @@ func IsResponseNotFound(res *gitlab.Response) bool {
 		return true
 	}
 	return false
+}
+
+// TokenHash returns a stable hex-encoded SHA-256 digest of the supplied token
+// value, or an empty string when no token is set. GitLab never returns webhook
+// secret tokens, so the digest is stored in status.atProvider to detect when a
+// referenced secret has been rotated on the desired side and must be re-pushed.
+// Only the digest is ever persisted, never the raw token.
+func TokenHash(token *string) string {
+	if token == nil {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(*token))
+	return hex.EncodeToString(sum[:])
 }

--- a/pkg/cluster/controller/groups/hooks/zz_controller.go
+++ b/pkg/cluster/controller/groups/hooks/zz_controller.go
@@ -148,12 +148,28 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	current := cr.Spec.ForProvider.DeepCopy()
 	groups.LateInitializeHook(&cr.Spec.ForProvider, grouphook)
 
+	// GenerateHookObservation rebuilds atProvider from the GitLab response,
+	// which never includes the secret token; preserve the stored token hash.
+	storedTokenHash := cr.Status.AtProvider.TokenHash
 	cr.Status.AtProvider = groups.GenerateHookObservation(grouphook)
+	cr.Status.AtProvider.TokenHash = storedTokenHash
 	cr.Status.SetConditions(v2.Available())
+
+	upToDate := groups.IsHookUpToDate(&cr.Spec.ForProvider, grouphook)
+	if upToDate {
+		// Only resolve the secret when every other field already matches:
+		// GitLab never returns the token, so we detect rotation on the desired
+		// side by comparing the current secret's hash to the stored one.
+		token, err := tokenValue(ctx, e.kube, cr)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, errSecretRefInvalid)
+		}
+		upToDate = clients.TokenHash(token) == storedTokenHash
+	}
 
 	return managed.ExternalObservation{
 		ResourceExists:          true,
-		ResourceUpToDate:        groups.IsHookUpToDate(&cr.Spec.ForProvider, grouphook),
+		ResourceUpToDate:        upToDate,
 		ResourceLateInitialized: !cmp.Equal(current, &cr.Spec.ForProvider),
 	}, nil
 }
@@ -210,6 +226,10 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	if err != nil {
 		return managed.ExternalUpdate{}, errors.Wrap(err, errUpdateFailed)
 	}
+
+	// Record the hash of the token we just pushed so Observe can detect future
+	// rotations of the referenced secret.
+	cr.Status.AtProvider.TokenHash = clients.TokenHash(token)
 
 	return managed.ExternalUpdate{}, nil
 }

--- a/pkg/cluster/controller/groups/hooks/zz_controller.go
+++ b/pkg/cluster/controller/groups/hooks/zz_controller.go
@@ -245,7 +245,16 @@ func (e *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 	if cr.Spec.ForProvider.GroupID == nil {
 		return managed.ExternalDelete{}, errors.New(errGroupIDMissing)
 	}
-	_, err := e.client.DeleteGroupHook(*cr.Spec.ForProvider.GroupID, cr.Status.AtProvider.ID, gitlab.WithContext(ctx))
+
+	// The external-name is the authoritative hook id (set on Create and used by
+	// Observe/Update); rely on it rather than status.atProvider.ID, which may be
+	// unset if the resource was never successfully observed.
+	hookid, err := strconv.ParseInt(meta.GetExternalName(cr), 10, 64)
+	if err != nil {
+		return managed.ExternalDelete{}, errors.New(errNotHook)
+	}
+
+	_, err = e.client.DeleteGroupHook(*cr.Spec.ForProvider.GroupID, hookid, gitlab.WithContext(ctx))
 	return managed.ExternalDelete{}, errors.Wrap(err, errDeleteFailed)
 }
 

--- a/pkg/cluster/controller/groups/hooks/zz_controller_test.go
+++ b/pkg/cluster/controller/groups/hooks/zz_controller_test.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane-contrib/provider-gitlab/apis/cluster/groups/v1alpha1"
+	"github.com/crossplane-contrib/provider-gitlab/pkg/cluster/clients"
 	"github.com/crossplane-contrib/provider-gitlab/pkg/cluster/clients/groups"
 	"github.com/crossplane-contrib/provider-gitlab/pkg/cluster/clients/groups/fake"
 	"github.com/crossplane-contrib/provider-gitlab/pkg/common"
@@ -48,11 +49,21 @@ var (
 	groupID     = int64(5678)
 	groupHookID = int64(1234)
 	tokenValueT = "test"
+	tokenHashT  = clients.TokenHash(&tokenValueT)
 	tokenSecret = corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"},
 		Data: map[string][]byte{
 			"token": []byte(tokenValueT),
 		},
+	}
+	// kubeWithSecret returns the token secret so Observe/Create/Update can
+	// resolve the referenced webhook token.
+	kubeWithSecret = &test.MockClient{
+		MockUpdate: test.NewMockUpdateFn(nil),
+		MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+			*obj.(*corev1.Secret) = tokenSecret
+			return nil
+		}),
 	}
 )
 
@@ -116,6 +127,10 @@ func withStatus(s v1alpha1.HookObservation) groupHookModifier {
 	return func(r *v1alpha1.Hook) { r.Status.AtProvider = s }
 }
 
+func withTokenHash(h string) groupHookModifier {
+	return func(r *v1alpha1.Hook) { r.Status.AtProvider.TokenHash = h }
+}
+
 func withExternalName(groupHookID int64) groupHookModifier {
 	return func(r *v1alpha1.Hook) { meta.SetExternalName(r, fmt.Sprint(groupHookID)) }
 }
@@ -141,6 +156,7 @@ func TestObserve(t *testing.T) {
 	}{
 		"SuccessfulAvailable": {
 			args: args{
+				kube: kubeWithSecret,
 				grouphook: &fake.MockClient{
 					MockGetGroupHook: func(gid interface{}, groupHookID int64, options ...gitlab.RequestOptionFunc) (*gitlab.GroupHook, *gitlab.Response, error) {
 						return &gitlab.GroupHook{}, &gitlab.Response{}, nil
@@ -153,17 +169,47 @@ func TestObserve(t *testing.T) {
 						ID:        groupHookID,
 						CreatedAt: &metav1.Time{Time: createTime},
 					}),
+					withTokenHash(tokenHashT),
 				),
 			},
 			want: want{
 				cr: grouphook(
 					withDefaultValues(),
 					withExternalName(groupHookID),
+					withTokenHash(tokenHashT),
 					withConditions(v2.Available()),
 				),
 				result: managed.ExternalObservation{
 					ResourceExists:   true,
 					ResourceUpToDate: true,
+				},
+			},
+		},
+		"TokenRotated": {
+			args: args{
+				kube: kubeWithSecret,
+				grouphook: &fake.MockClient{
+					MockGetGroupHook: func(gid interface{}, groupHookID int64, options ...gitlab.RequestOptionFunc) (*gitlab.GroupHook, *gitlab.Response, error) {
+						return &gitlab.GroupHook{}, &gitlab.Response{}, nil
+					},
+				},
+				cr: grouphook(
+					withDefaultValues(),
+					withExternalName(groupHookID),
+					withStatus(v1alpha1.HookObservation{ID: groupHookID}),
+					withTokenHash("stale-hash"),
+				),
+			},
+			want: want{
+				cr: grouphook(
+					withDefaultValues(),
+					withExternalName(groupHookID),
+					withTokenHash("stale-hash"),
+					withConditions(v2.Available()),
+				),
+				result: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: false,
 				},
 			},
 		},
@@ -199,6 +245,7 @@ func TestObserve(t *testing.T) {
 		},
 		"LateInitSuccess": {
 			args: args{
+				kube: kubeWithSecret,
 				grouphook: &fake.MockClient{
 					MockGetGroupHook: func(gid interface{}, groupHookID int64, options ...gitlab.RequestOptionFunc) (*gitlab.GroupHook, *gitlab.Response, error) {
 						return &gitlab.GroupHook{}, &gitlab.Response{}, nil
@@ -212,12 +259,14 @@ func TestObserve(t *testing.T) {
 						ID:        groupHookID,
 						CreatedAt: &metav1.Time{Time: createTime},
 					}),
+					withTokenHash(tokenHashT),
 				),
 			},
 			want: want{
 				cr: grouphook(
 					withDefaultValues(),
 					withExternalName(groupHookID),
+					withTokenHash(tokenHashT),
 					withConditions(v2.Available()),
 				),
 				result: managed.ExternalObservation{
@@ -387,6 +436,7 @@ func TestUpdate(t *testing.T) {
 					withTokenRef(),
 					withGroupID(groupID),
 					withStatus(v1alpha1.HookObservation{ID: groupHookID}),
+					withTokenHash(tokenHashT),
 				),
 			},
 		},

--- a/pkg/cluster/controller/groups/hooks/zz_controller_test.go
+++ b/pkg/cluster/controller/groups/hooks/zz_controller_test.go
@@ -510,6 +510,7 @@ func TestDelete(t *testing.T) {
 				},
 				cr: grouphook(
 					withGroupID(groupID),
+					withExternalName(groupHookID),
 					withStatus(v1alpha1.HookObservation{
 						ID: groupHookID,
 					}),
@@ -519,6 +520,7 @@ func TestDelete(t *testing.T) {
 			want: want{
 				cr: grouphook(
 					withGroupID(groupID),
+					withExternalName(groupHookID),
 					withStatus(v1alpha1.HookObservation{
 						ID: groupHookID,
 					}),
@@ -535,6 +537,7 @@ func TestDelete(t *testing.T) {
 				},
 				cr: grouphook(
 					withGroupID(groupID),
+					withExternalName(groupHookID),
 					withStatus(v1alpha1.HookObservation{
 						ID: groupHookID,
 					}),
@@ -544,6 +547,7 @@ func TestDelete(t *testing.T) {
 			want: want{
 				cr: grouphook(
 					withGroupID(groupID),
+					withExternalName(groupHookID),
 					withStatus(v1alpha1.HookObservation{
 						ID: groupHookID,
 					}),

--- a/pkg/cluster/controller/projects/hooks/zz_controller.go
+++ b/pkg/cluster/controller/projects/hooks/zz_controller.go
@@ -142,18 +142,34 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		if clients.IsResponseNotFound(res) {
 			return managed.ExternalObservation{}, nil
 		}
-		return managed.ExternalObservation{}, errors.Wrap(resource.Ignore(projects.IsErrorHookNotFound, err), errGetFailed)
+		return managed.ExternalObservation{}, errors.Wrap(err, errGetFailed)
 	}
 
 	current := cr.Spec.ForProvider.DeepCopy()
 	projects.LateInitializeHook(&cr.Spec.ForProvider, projecthook)
 
+	// GenerateHookObservation rebuilds atProvider from the GitLab response,
+	// which never includes the secret token; preserve the stored token hash.
+	storedTokenHash := cr.Status.AtProvider.TokenHash
 	cr.Status.AtProvider = projects.GenerateHookObservation(projecthook)
+	cr.Status.AtProvider.TokenHash = storedTokenHash
 	cr.Status.SetConditions(v2.Available())
+
+	upToDate := projects.IsHookUpToDate(&cr.Spec.ForProvider, projecthook)
+	if upToDate {
+		// Only resolve the secret when every other field already matches:
+		// GitLab never returns the token, so we detect rotation on the desired
+		// side by comparing the current secret's hash to the stored one.
+		token, err := tokenValue(ctx, e.kube, cr)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, errSecretRefInvalid)
+		}
+		upToDate = clients.TokenHash(token) == storedTokenHash
+	}
 
 	return managed.ExternalObservation{
 		ResourceExists:          true,
-		ResourceUpToDate:        projects.IsHookUpToDate(&cr.Spec.ForProvider, projecthook),
+		ResourceUpToDate:        upToDate,
 		ResourceLateInitialized: !cmp.Equal(current, &cr.Spec.ForProvider),
 	}, nil
 }
@@ -194,7 +210,7 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalUpdate{}, errors.New(errProjectIDMissing)
 	}
 
-	token, err := common.GetTokenValueFromSecret(ctx, e.kube, mg, cr.Spec.ForProvider.Token.SecretRef)
+	token, err := tokenValue(ctx, e.kube, cr)
 	if err != nil {
 		return managed.ExternalUpdate{}, errors.Wrap(err, errSecretRefInvalid)
 	}
@@ -205,6 +221,10 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	if err != nil {
 		return managed.ExternalUpdate{}, errors.Wrap(err, errUpdateFailed)
 	}
+
+	// Record the hash of the token we just pushed so Observe can detect future
+	// rotations of the referenced secret.
+	cr.Status.AtProvider.TokenHash = clients.TokenHash(token)
 
 	return managed.ExternalUpdate{}, nil
 }
@@ -232,4 +252,13 @@ func (e *external) Disconnect(ctx context.Context) error {
 func (e *external) updateExternalName(ctx context.Context, cr *v1alpha1.Hook, projecthook *gitlab.ProjectHook) error {
 	meta.SetExternalName(cr, strconv.FormatInt(projecthook.ID, 10))
 	return e.kube.Update(ctx, cr)
+}
+
+// tokenValue resolves the webhook secret token from the referenced secret.
+// A nil token reference yields a nil value rather than an error.
+func tokenValue(ctx context.Context, kube client.Client, cr *v1alpha1.Hook) (*string, error) {
+	if cr.Spec.ForProvider.Token == nil || cr.Spec.ForProvider.Token.SecretRef == nil {
+		return nil, nil
+	}
+	return common.GetTokenValueFromSecret(ctx, kube, cr, cr.Spec.ForProvider.Token.SecretRef)
 }

--- a/pkg/cluster/controller/projects/hooks/zz_controller.go
+++ b/pkg/cluster/controller/projects/hooks/zz_controller.go
@@ -240,7 +240,16 @@ func (e *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 	if cr.Spec.ForProvider.ProjectID == nil {
 		return managed.ExternalDelete{}, errors.New(errProjectIDMissing)
 	}
-	_, err := e.client.DeleteProjectHook(*cr.Spec.ForProvider.ProjectID, cr.Status.AtProvider.ID, gitlab.WithContext(ctx))
+
+	// The external-name is the authoritative hook id (set on Create and used by
+	// Observe/Update); rely on it rather than status.atProvider.ID, which may be
+	// unset if the resource was never successfully observed.
+	hookid, err := strconv.ParseInt(meta.GetExternalName(cr), 10, 64)
+	if err != nil {
+		return managed.ExternalDelete{}, errors.New(errNotHook)
+	}
+
+	_, err = e.client.DeleteProjectHook(*cr.Spec.ForProvider.ProjectID, hookid, gitlab.WithContext(ctx))
 	return managed.ExternalDelete{}, errors.Wrap(err, errDeleteFailed)
 }
 

--- a/pkg/cluster/controller/projects/hooks/zz_controller_test.go
+++ b/pkg/cluster/controller/projects/hooks/zz_controller_test.go
@@ -504,6 +504,7 @@ func TestDelete(t *testing.T) {
 				},
 				cr: projecthook(
 					withProjectID(projectID),
+					withExternalName(projectHookID),
 					withStatus(v1alpha1.HookObservation{
 						ID: projectHookID,
 					}),
@@ -513,6 +514,7 @@ func TestDelete(t *testing.T) {
 			want: want{
 				cr: projecthook(
 					withProjectID(projectID),
+					withExternalName(projectHookID),
 					withStatus(v1alpha1.HookObservation{
 						ID: projectHookID,
 					}),
@@ -529,6 +531,7 @@ func TestDelete(t *testing.T) {
 				},
 				cr: projecthook(
 					withProjectID(projectID),
+					withExternalName(projectHookID),
 					withStatus(v1alpha1.HookObservation{
 						ID: projectHookID,
 					}),
@@ -538,6 +541,7 @@ func TestDelete(t *testing.T) {
 			want: want{
 				cr: projecthook(
 					withProjectID(projectID),
+					withExternalName(projectHookID),
 					withStatus(v1alpha1.HookObservation{
 						ID: projectHookID,
 					}),
@@ -563,6 +567,7 @@ func TestDelete(t *testing.T) {
 					withProjectID(projectID),
 					withConditions(v2.Deleting()),
 				),
+				err: errors.New(errNotHook),
 			},
 		},
 	}

--- a/pkg/cluster/controller/projects/hooks/zz_controller_test.go
+++ b/pkg/cluster/controller/projects/hooks/zz_controller_test.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane-contrib/provider-gitlab/apis/cluster/projects/v1alpha1"
+	"github.com/crossplane-contrib/provider-gitlab/pkg/cluster/clients"
 	"github.com/crossplane-contrib/provider-gitlab/pkg/cluster/clients/projects"
 	"github.com/crossplane-contrib/provider-gitlab/pkg/cluster/clients/projects/fake"
 	"github.com/crossplane-contrib/provider-gitlab/pkg/common"
@@ -47,12 +48,22 @@ var (
 	createTime    = time.Now()
 	projectID     = int64(5678)
 	projectHookID = int64(1234)
-	tokenValue    = "test"
+	tokenValueT   = "test"
+	tokenHashT    = clients.TokenHash(&tokenValueT)
 	tokenSecret   = corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"},
 		Data: map[string][]byte{
-			"token": []byte(tokenValue),
+			"token": []byte(tokenValueT),
 		},
+	}
+	// kubeWithSecret returns the token secret so Observe/Create/Update can
+	// resolve the referenced webhook token.
+	kubeWithSecret = &test.MockClient{
+		MockUpdate: test.NewMockUpdateFn(nil),
+		MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+			*obj.(*corev1.Secret) = tokenSecret
+			return nil
+		}),
 	}
 )
 
@@ -111,6 +122,10 @@ func withStatus(s v1alpha1.HookObservation) projectHookModifier {
 	return func(r *v1alpha1.Hook) { r.Status.AtProvider = s }
 }
 
+func withTokenHash(h string) projectHookModifier {
+	return func(r *v1alpha1.Hook) { r.Status.AtProvider.TokenHash = h }
+}
+
 func withExternalName(projectHookID int64) projectHookModifier {
 	return func(r *v1alpha1.Hook) { meta.SetExternalName(r, fmt.Sprint(projectHookID)) }
 }
@@ -136,6 +151,7 @@ func TestObserve(t *testing.T) {
 	}{
 		"SuccessfulAvailable": {
 			args: args{
+				kube: kubeWithSecret,
 				projecthook: &fake.MockClient{
 					MockGetHook: func(pid interface{}, projectHookID int64, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectHook, *gitlab.Response, error) {
 						return &gitlab.ProjectHook{}, &gitlab.Response{}, nil
@@ -148,17 +164,47 @@ func TestObserve(t *testing.T) {
 						ID:        projectHookID,
 						CreatedAt: &metav1.Time{Time: createTime},
 					}),
+					withTokenHash(tokenHashT),
 				),
 			},
 			want: want{
 				cr: projecthook(
 					withDefaultValues(),
 					withExternalName(projectHookID),
+					withTokenHash(tokenHashT),
 					withConditions(v2.Available()),
 				),
 				result: managed.ExternalObservation{
 					ResourceExists:   true,
 					ResourceUpToDate: true,
+				},
+			},
+		},
+		"TokenRotated": {
+			args: args{
+				kube: kubeWithSecret,
+				projecthook: &fake.MockClient{
+					MockGetHook: func(pid interface{}, projectHookID int64, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectHook, *gitlab.Response, error) {
+						return &gitlab.ProjectHook{}, &gitlab.Response{}, nil
+					},
+				},
+				cr: projecthook(
+					withDefaultValues(),
+					withExternalName(projectHookID),
+					withStatus(v1alpha1.HookObservation{ID: projectHookID}),
+					withTokenHash("stale-hash"),
+				),
+			},
+			want: want{
+				cr: projecthook(
+					withDefaultValues(),
+					withExternalName(projectHookID),
+					withTokenHash("stale-hash"),
+					withConditions(v2.Available()),
+				),
+				result: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: false,
 				},
 			},
 		},
@@ -194,6 +240,7 @@ func TestObserve(t *testing.T) {
 		},
 		"LateInitSuccess": {
 			args: args{
+				kube: kubeWithSecret,
 				projecthook: &fake.MockClient{
 					MockGetHook: func(pid interface{}, projectHookID int64, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectHook, *gitlab.Response, error) {
 						return &gitlab.ProjectHook{}, &gitlab.Response{}, nil
@@ -207,12 +254,14 @@ func TestObserve(t *testing.T) {
 						ID:        projectHookID,
 						CreatedAt: &metav1.Time{Time: createTime},
 					}),
+					withTokenHash(tokenHashT),
 				),
 			},
 			want: want{
 				cr: projecthook(
 					withDefaultValues(),
 					withExternalName(projectHookID),
+					withTokenHash(tokenHashT),
 					withConditions(v2.Available()),
 				),
 				result: managed.ExternalObservation{
@@ -382,6 +431,7 @@ func TestUpdate(t *testing.T) {
 					withTokenRef(),
 					withProjectID(projectID),
 					withStatus(v1alpha1.HookObservation{ID: projectHookID}),
+					withTokenHash(tokenHashT),
 				),
 			},
 		},

--- a/pkg/namespaced/clients/gitlab.go
+++ b/pkg/namespaced/clients/gitlab.go
@@ -17,6 +17,8 @@ limitations under the License.
 package clients
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -244,4 +246,17 @@ func IsResponseNotFound(res *gitlab.Response) bool {
 		return true
 	}
 	return false
+}
+
+// TokenHash returns a stable hex-encoded SHA-256 digest of the supplied token
+// value, or an empty string when no token is set. GitLab never returns webhook
+// secret tokens, so the digest is stored in status.atProvider to detect when a
+// referenced secret has been rotated on the desired side and must be re-pushed.
+// Only the digest is ever persisted, never the raw token.
+func TokenHash(token *string) string {
+	if token == nil {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(*token))
+	return hex.EncodeToString(sum[:])
 }

--- a/pkg/namespaced/clients/projects/hook.go
+++ b/pkg/namespaced/clients/projects/hook.go
@@ -17,8 +17,6 @@ limitations under the License.
 package projects
 
 import (
-	"strings"
-
 	"github.com/google/go-cmp/cmp"
 	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,10 +24,6 @@ import (
 	"github.com/crossplane-contrib/provider-gitlab/apis/namespaced/projects/v1alpha1"
 	"github.com/crossplane-contrib/provider-gitlab/pkg/common"
 	"github.com/crossplane-contrib/provider-gitlab/pkg/namespaced/clients"
-)
-
-const (
-	errHookNotFound = "404 Not found"
 )
 
 // HookClient defines Gitlab Hook service operations
@@ -44,14 +38,6 @@ type HookClient interface {
 func NewHookClient(cfg common.Config) HookClient {
 	git := common.NewClient(cfg)
 	return git.Projects
-}
-
-// IsErrorHookNotFound helper function to test for errProjectNotFound error.
-func IsErrorHookNotFound(err error) bool {
-	if err == nil {
-		return false
-	}
-	return strings.Contains(err.Error(), errHookNotFound)
 }
 
 // LateInitializeHook fills the empty fields in the hook spec with the

--- a/pkg/namespaced/controller/groups/hooks/controller.go
+++ b/pkg/namespaced/controller/groups/hooks/controller.go
@@ -146,12 +146,28 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	current := cr.Spec.ForProvider.DeepCopy()
 	groups.LateInitializeHook(&cr.Spec.ForProvider, grouphook)
 
+	// GenerateHookObservation rebuilds atProvider from the GitLab response,
+	// which never includes the secret token; preserve the stored token hash.
+	storedTokenHash := cr.Status.AtProvider.TokenHash
 	cr.Status.AtProvider = groups.GenerateHookObservation(grouphook)
+	cr.Status.AtProvider.TokenHash = storedTokenHash
 	cr.Status.SetConditions(v2.Available())
+
+	upToDate := groups.IsHookUpToDate(&cr.Spec.ForProvider, grouphook)
+	if upToDate {
+		// Only resolve the secret when every other field already matches:
+		// GitLab never returns the token, so we detect rotation on the desired
+		// side by comparing the current secret's hash to the stored one.
+		token, err := tokenValue(ctx, e.kube, cr)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, errSecretRefInvalid)
+		}
+		upToDate = clients.TokenHash(token) == storedTokenHash
+	}
 
 	return managed.ExternalObservation{
 		ResourceExists:          true,
-		ResourceUpToDate:        groups.IsHookUpToDate(&cr.Spec.ForProvider, grouphook),
+		ResourceUpToDate:        upToDate,
 		ResourceLateInitialized: !cmp.Equal(current, &cr.Spec.ForProvider),
 	}, nil
 }
@@ -208,6 +224,10 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	if err != nil {
 		return managed.ExternalUpdate{}, errors.Wrap(err, errUpdateFailed)
 	}
+
+	// Record the hash of the token we just pushed so Observe can detect future
+	// rotations of the referenced secret.
+	cr.Status.AtProvider.TokenHash = clients.TokenHash(token)
 
 	return managed.ExternalUpdate{}, nil
 }

--- a/pkg/namespaced/controller/groups/hooks/controller.go
+++ b/pkg/namespaced/controller/groups/hooks/controller.go
@@ -243,7 +243,16 @@ func (e *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 	if cr.Spec.ForProvider.GroupID == nil {
 		return managed.ExternalDelete{}, errors.New(errGroupIDMissing)
 	}
-	_, err := e.client.DeleteGroupHook(*cr.Spec.ForProvider.GroupID, cr.Status.AtProvider.ID, gitlab.WithContext(ctx))
+
+	// The external-name is the authoritative hook id (set on Create and used by
+	// Observe/Update); rely on it rather than status.atProvider.ID, which may be
+	// unset if the resource was never successfully observed.
+	hookid, err := strconv.ParseInt(meta.GetExternalName(cr), 10, 64)
+	if err != nil {
+		return managed.ExternalDelete{}, errors.New(errNotHook)
+	}
+
+	_, err = e.client.DeleteGroupHook(*cr.Spec.ForProvider.GroupID, hookid, gitlab.WithContext(ctx))
 	return managed.ExternalDelete{}, errors.Wrap(err, errDeleteFailed)
 }
 

--- a/pkg/namespaced/controller/groups/hooks/controller_test.go
+++ b/pkg/namespaced/controller/groups/hooks/controller_test.go
@@ -508,6 +508,7 @@ func TestDelete(t *testing.T) {
 				},
 				cr: grouphook(
 					withGroupID(groupID),
+					withExternalName(groupHookID),
 					withStatus(v1alpha1.HookObservation{
 						ID: groupHookID,
 					}),
@@ -517,6 +518,7 @@ func TestDelete(t *testing.T) {
 			want: want{
 				cr: grouphook(
 					withGroupID(groupID),
+					withExternalName(groupHookID),
 					withStatus(v1alpha1.HookObservation{
 						ID: groupHookID,
 					}),
@@ -533,6 +535,7 @@ func TestDelete(t *testing.T) {
 				},
 				cr: grouphook(
 					withGroupID(groupID),
+					withExternalName(groupHookID),
 					withStatus(v1alpha1.HookObservation{
 						ID: groupHookID,
 					}),
@@ -542,6 +545,7 @@ func TestDelete(t *testing.T) {
 			want: want{
 				cr: grouphook(
 					withGroupID(groupID),
+					withExternalName(groupHookID),
 					withStatus(v1alpha1.HookObservation{
 						ID: groupHookID,
 					}),

--- a/pkg/namespaced/controller/groups/hooks/controller_test.go
+++ b/pkg/namespaced/controller/groups/hooks/controller_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/crossplane-contrib/provider-gitlab/apis/namespaced/groups/v1alpha1"
 	"github.com/crossplane-contrib/provider-gitlab/pkg/common"
+	"github.com/crossplane-contrib/provider-gitlab/pkg/namespaced/clients"
 	"github.com/crossplane-contrib/provider-gitlab/pkg/namespaced/clients/groups"
 	"github.com/crossplane-contrib/provider-gitlab/pkg/namespaced/clients/groups/fake"
 )
@@ -46,11 +47,21 @@ var (
 	groupID     = int64(5678)
 	groupHookID = int64(1234)
 	tokenValueT = "test"
+	tokenHashT  = clients.TokenHash(&tokenValueT)
 	tokenSecret = corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"},
 		Data: map[string][]byte{
 			"token": []byte(tokenValueT),
 		},
+	}
+	// kubeWithSecret returns the token secret so Observe/Create/Update can
+	// resolve the referenced webhook token.
+	kubeWithSecret = &test.MockClient{
+		MockUpdate: test.NewMockUpdateFn(nil),
+		MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+			*obj.(*corev1.Secret) = tokenSecret
+			return nil
+		}),
 	}
 )
 
@@ -114,6 +125,10 @@ func withStatus(s v1alpha1.HookObservation) groupHookModifier {
 	return func(r *v1alpha1.Hook) { r.Status.AtProvider = s }
 }
 
+func withTokenHash(h string) groupHookModifier {
+	return func(r *v1alpha1.Hook) { r.Status.AtProvider.TokenHash = h }
+}
+
 func withExternalName(groupHookID int64) groupHookModifier {
 	return func(r *v1alpha1.Hook) { meta.SetExternalName(r, fmt.Sprint(groupHookID)) }
 }
@@ -139,6 +154,7 @@ func TestObserve(t *testing.T) {
 	}{
 		"SuccessfulAvailable": {
 			args: args{
+				kube: kubeWithSecret,
 				grouphook: &fake.MockClient{
 					MockGetGroupHook: func(gid interface{}, groupHookID int64, options ...gitlab.RequestOptionFunc) (*gitlab.GroupHook, *gitlab.Response, error) {
 						return &gitlab.GroupHook{}, &gitlab.Response{}, nil
@@ -151,17 +167,47 @@ func TestObserve(t *testing.T) {
 						ID:        groupHookID,
 						CreatedAt: &metav1.Time{Time: createTime},
 					}),
+					withTokenHash(tokenHashT),
 				),
 			},
 			want: want{
 				cr: grouphook(
 					withDefaultValues(),
 					withExternalName(groupHookID),
+					withTokenHash(tokenHashT),
 					withConditions(v2.Available()),
 				),
 				result: managed.ExternalObservation{
 					ResourceExists:   true,
 					ResourceUpToDate: true,
+				},
+			},
+		},
+		"TokenRotated": {
+			args: args{
+				kube: kubeWithSecret,
+				grouphook: &fake.MockClient{
+					MockGetGroupHook: func(gid interface{}, groupHookID int64, options ...gitlab.RequestOptionFunc) (*gitlab.GroupHook, *gitlab.Response, error) {
+						return &gitlab.GroupHook{}, &gitlab.Response{}, nil
+					},
+				},
+				cr: grouphook(
+					withDefaultValues(),
+					withExternalName(groupHookID),
+					withStatus(v1alpha1.HookObservation{ID: groupHookID}),
+					withTokenHash("stale-hash"),
+				),
+			},
+			want: want{
+				cr: grouphook(
+					withDefaultValues(),
+					withExternalName(groupHookID),
+					withTokenHash("stale-hash"),
+					withConditions(v2.Available()),
+				),
+				result: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: false,
 				},
 			},
 		},
@@ -197,6 +243,7 @@ func TestObserve(t *testing.T) {
 		},
 		"LateInitSuccess": {
 			args: args{
+				kube: kubeWithSecret,
 				grouphook: &fake.MockClient{
 					MockGetGroupHook: func(gid interface{}, groupHookID int64, options ...gitlab.RequestOptionFunc) (*gitlab.GroupHook, *gitlab.Response, error) {
 						return &gitlab.GroupHook{}, &gitlab.Response{}, nil
@@ -210,12 +257,14 @@ func TestObserve(t *testing.T) {
 						ID:        groupHookID,
 						CreatedAt: &metav1.Time{Time: createTime},
 					}),
+					withTokenHash(tokenHashT),
 				),
 			},
 			want: want{
 				cr: grouphook(
 					withDefaultValues(),
 					withExternalName(groupHookID),
+					withTokenHash(tokenHashT),
 					withConditions(v2.Available()),
 				),
 				result: managed.ExternalObservation{
@@ -385,6 +434,7 @@ func TestUpdate(t *testing.T) {
 					withTokenRef(),
 					withGroupID(groupID),
 					withStatus(v1alpha1.HookObservation{ID: groupHookID}),
+					withTokenHash(tokenHashT),
 				),
 			},
 		},

--- a/pkg/namespaced/controller/projects/hooks/controller.go
+++ b/pkg/namespaced/controller/projects/hooks/controller.go
@@ -140,18 +140,34 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		if clients.IsResponseNotFound(res) {
 			return managed.ExternalObservation{}, nil
 		}
-		return managed.ExternalObservation{}, errors.Wrap(resource.Ignore(projects.IsErrorHookNotFound, err), errGetFailed)
+		return managed.ExternalObservation{}, errors.Wrap(err, errGetFailed)
 	}
 
 	current := cr.Spec.ForProvider.DeepCopy()
 	projects.LateInitializeHook(&cr.Spec.ForProvider, projecthook)
 
+	// GenerateHookObservation rebuilds atProvider from the GitLab response,
+	// which never includes the secret token; preserve the stored token hash.
+	storedTokenHash := cr.Status.AtProvider.TokenHash
 	cr.Status.AtProvider = projects.GenerateHookObservation(projecthook)
+	cr.Status.AtProvider.TokenHash = storedTokenHash
 	cr.Status.SetConditions(v2.Available())
+
+	upToDate := projects.IsHookUpToDate(&cr.Spec.ForProvider, projecthook)
+	if upToDate {
+		// Only resolve the secret when every other field already matches:
+		// GitLab never returns the token, so we detect rotation on the desired
+		// side by comparing the current secret's hash to the stored one.
+		token, err := tokenValue(ctx, e.kube, cr)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, errSecretRefInvalid)
+		}
+		upToDate = clients.TokenHash(token) == storedTokenHash
+	}
 
 	return managed.ExternalObservation{
 		ResourceExists:          true,
-		ResourceUpToDate:        projects.IsHookUpToDate(&cr.Spec.ForProvider, projecthook),
+		ResourceUpToDate:        upToDate,
 		ResourceLateInitialized: !cmp.Equal(current, &cr.Spec.ForProvider),
 	}, nil
 }
@@ -192,7 +208,7 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalUpdate{}, errors.New(errProjectIDMissing)
 	}
 
-	token, err := common.GetTokenValueFromLocalSecret(ctx, e.kube, mg, cr.Spec.ForProvider.Token.SecretRef)
+	token, err := tokenValue(ctx, e.kube, cr)
 	if err != nil {
 		return managed.ExternalUpdate{}, errors.Wrap(err, errSecretRefInvalid)
 	}
@@ -203,6 +219,10 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 	if err != nil {
 		return managed.ExternalUpdate{}, errors.Wrap(err, errUpdateFailed)
 	}
+
+	// Record the hash of the token we just pushed so Observe can detect future
+	// rotations of the referenced secret.
+	cr.Status.AtProvider.TokenHash = clients.TokenHash(token)
 
 	return managed.ExternalUpdate{}, nil
 }
@@ -230,4 +250,13 @@ func (e *external) Disconnect(ctx context.Context) error {
 func (e *external) updateExternalName(ctx context.Context, cr *v1alpha1.Hook, projecthook *gitlab.ProjectHook) error {
 	meta.SetExternalName(cr, strconv.FormatInt(projecthook.ID, 10))
 	return e.kube.Update(ctx, cr)
+}
+
+// tokenValue resolves the webhook secret token from the referenced secret.
+// A nil token reference yields a nil value rather than an error.
+func tokenValue(ctx context.Context, kube client.Client, cr *v1alpha1.Hook) (*string, error) {
+	if cr.Spec.ForProvider.Token == nil || cr.Spec.ForProvider.Token.SecretRef == nil {
+		return nil, nil
+	}
+	return common.GetTokenValueFromLocalSecret(ctx, kube, cr, cr.Spec.ForProvider.Token.SecretRef)
 }

--- a/pkg/namespaced/controller/projects/hooks/controller.go
+++ b/pkg/namespaced/controller/projects/hooks/controller.go
@@ -238,7 +238,16 @@ func (e *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 	if cr.Spec.ForProvider.ProjectID == nil {
 		return managed.ExternalDelete{}, errors.New(errProjectIDMissing)
 	}
-	_, err := e.client.DeleteProjectHook(*cr.Spec.ForProvider.ProjectID, cr.Status.AtProvider.ID, gitlab.WithContext(ctx))
+
+	// The external-name is the authoritative hook id (set on Create and used by
+	// Observe/Update); rely on it rather than status.atProvider.ID, which may be
+	// unset if the resource was never successfully observed.
+	hookid, err := strconv.ParseInt(meta.GetExternalName(cr), 10, 64)
+	if err != nil {
+		return managed.ExternalDelete{}, errors.New(errNotHook)
+	}
+
+	_, err = e.client.DeleteProjectHook(*cr.Spec.ForProvider.ProjectID, hookid, gitlab.WithContext(ctx))
 	return managed.ExternalDelete{}, errors.Wrap(err, errDeleteFailed)
 }
 

--- a/pkg/namespaced/controller/projects/hooks/controller_test.go
+++ b/pkg/namespaced/controller/projects/hooks/controller_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/crossplane-contrib/provider-gitlab/apis/namespaced/projects/v1alpha1"
 	"github.com/crossplane-contrib/provider-gitlab/pkg/common"
+	"github.com/crossplane-contrib/provider-gitlab/pkg/namespaced/clients"
 	"github.com/crossplane-contrib/provider-gitlab/pkg/namespaced/clients/projects"
 	"github.com/crossplane-contrib/provider-gitlab/pkg/namespaced/clients/projects/fake"
 )
@@ -45,12 +46,22 @@ var (
 	createTime    = time.Now()
 	projectID     = int64(5678)
 	projectHookID = int64(1234)
-	tokenValue    = "test"
+	tokenValueT   = "test"
+	tokenHashT    = clients.TokenHash(&tokenValueT)
 	tokenSecret   = corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "test"},
 		Data: map[string][]byte{
-			"token": []byte(tokenValue),
+			"token": []byte(tokenValueT),
 		},
+	}
+	// kubeWithSecret returns the token secret so Observe/Create/Update can
+	// resolve the referenced webhook token.
+	kubeWithSecret = &test.MockClient{
+		MockUpdate: test.NewMockUpdateFn(nil),
+		MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+			*obj.(*corev1.Secret) = tokenSecret
+			return nil
+		}),
 	}
 )
 
@@ -109,6 +120,10 @@ func withStatus(s v1alpha1.HookObservation) projectHookModifier {
 	return func(r *v1alpha1.Hook) { r.Status.AtProvider = s }
 }
 
+func withTokenHash(h string) projectHookModifier {
+	return func(r *v1alpha1.Hook) { r.Status.AtProvider.TokenHash = h }
+}
+
 func withExternalName(projectHookID int64) projectHookModifier {
 	return func(r *v1alpha1.Hook) { meta.SetExternalName(r, fmt.Sprint(projectHookID)) }
 }
@@ -134,6 +149,7 @@ func TestObserve(t *testing.T) {
 	}{
 		"SuccessfulAvailable": {
 			args: args{
+				kube: kubeWithSecret,
 				projecthook: &fake.MockClient{
 					MockGetHook: func(pid interface{}, projectHookID int64, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectHook, *gitlab.Response, error) {
 						return &gitlab.ProjectHook{}, &gitlab.Response{}, nil
@@ -146,17 +162,47 @@ func TestObserve(t *testing.T) {
 						ID:        projectHookID,
 						CreatedAt: &metav1.Time{Time: createTime},
 					}),
+					withTokenHash(tokenHashT),
 				),
 			},
 			want: want{
 				cr: projecthook(
 					withDefaultValues(),
 					withExternalName(projectHookID),
+					withTokenHash(tokenHashT),
 					withConditions(v2.Available()),
 				),
 				result: managed.ExternalObservation{
 					ResourceExists:   true,
 					ResourceUpToDate: true,
+				},
+			},
+		},
+		"TokenRotated": {
+			args: args{
+				kube: kubeWithSecret,
+				projecthook: &fake.MockClient{
+					MockGetHook: func(pid interface{}, projectHookID int64, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectHook, *gitlab.Response, error) {
+						return &gitlab.ProjectHook{}, &gitlab.Response{}, nil
+					},
+				},
+				cr: projecthook(
+					withDefaultValues(),
+					withExternalName(projectHookID),
+					withStatus(v1alpha1.HookObservation{ID: projectHookID}),
+					withTokenHash("stale-hash"),
+				),
+			},
+			want: want{
+				cr: projecthook(
+					withDefaultValues(),
+					withExternalName(projectHookID),
+					withTokenHash("stale-hash"),
+					withConditions(v2.Available()),
+				),
+				result: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: false,
 				},
 			},
 		},
@@ -192,6 +238,7 @@ func TestObserve(t *testing.T) {
 		},
 		"LateInitSuccess": {
 			args: args{
+				kube: kubeWithSecret,
 				projecthook: &fake.MockClient{
 					MockGetHook: func(pid interface{}, projectHookID int64, options ...gitlab.RequestOptionFunc) (*gitlab.ProjectHook, *gitlab.Response, error) {
 						return &gitlab.ProjectHook{}, &gitlab.Response{}, nil
@@ -205,12 +252,14 @@ func TestObserve(t *testing.T) {
 						ID:        projectHookID,
 						CreatedAt: &metav1.Time{Time: createTime},
 					}),
+					withTokenHash(tokenHashT),
 				),
 			},
 			want: want{
 				cr: projecthook(
 					withDefaultValues(),
 					withExternalName(projectHookID),
+					withTokenHash(tokenHashT),
 					withConditions(v2.Available()),
 				),
 				result: managed.ExternalObservation{
@@ -380,6 +429,7 @@ func TestUpdate(t *testing.T) {
 					withTokenRef(),
 					withProjectID(projectID),
 					withStatus(v1alpha1.HookObservation{ID: projectHookID}),
+					withTokenHash(tokenHashT),
 				),
 			},
 		},

--- a/pkg/namespaced/controller/projects/hooks/controller_test.go
+++ b/pkg/namespaced/controller/projects/hooks/controller_test.go
@@ -502,6 +502,7 @@ func TestDelete(t *testing.T) {
 				},
 				cr: projecthook(
 					withProjectID(projectID),
+					withExternalName(projectHookID),
 					withStatus(v1alpha1.HookObservation{
 						ID: projectHookID,
 					}),
@@ -511,6 +512,7 @@ func TestDelete(t *testing.T) {
 			want: want{
 				cr: projecthook(
 					withProjectID(projectID),
+					withExternalName(projectHookID),
 					withStatus(v1alpha1.HookObservation{
 						ID: projectHookID,
 					}),
@@ -527,6 +529,7 @@ func TestDelete(t *testing.T) {
 				},
 				cr: projecthook(
 					withProjectID(projectID),
+					withExternalName(projectHookID),
 					withStatus(v1alpha1.HookObservation{
 						ID: projectHookID,
 					}),
@@ -536,6 +539,7 @@ func TestDelete(t *testing.T) {
 			want: want{
 				cr: projecthook(
 					withProjectID(projectID),
+					withExternalName(projectHookID),
 					withStatus(v1alpha1.HookObservation{
 						ID: projectHookID,
 					}),
@@ -561,6 +565,7 @@ func TestDelete(t *testing.T) {
 					withProjectID(projectID),
 					withConditions(v2.Deleting()),
 				),
+				err: errors.New(errNotHook),
 			},
 		},
 	}


### PR DESCRIPTION
## Description of your changes

Fixes #374. Reconciles webhook **token rotation** for both the group `Hook` and the project `Hook`, plus two related project-`Hook` consistency fixes.

### Token rotation (group + project)
GitLab never returns the webhook secret, so `IsHookUpToDate` can't compare it and `Update` only ran when some *other* field drifted. Rotating only the referenced secret was therefore never propagated.

The change detects rotation on the **desired** side:
- New `status.atProvider.tokenHash` holds a SHA-256 digest of the token last pushed (never the raw token), via a shared `clients.TokenHash` helper.
- `Observe` resolves the secret — only when every other field already matches — and compares its hash to the stored one; a mismatch drives `Update`.
- `Update` re-pushes the token and rewrites the digest.
- The hash is written in `Update` (crossplane-runtime reverts status changes made during `Create`), so a freshly created hook with a token self-corrects via a single `Update`.

### Project `Hook` consistency (mirroring the group `Hook`)
- Enforce `projectId` immutability with a CEL `XValidation` rule.
- Remove the dead `errHookNotFound` / `IsErrorHookNotFound` matcher (GitLab returns `"404 Not Found"`; not-found is already handled by `clients.IsResponseNotFound` on the response status).

## How has this code been tested

`go build ./...`, `go vet ./...`, `go test ./...` all pass; new unit tests cover the token-rotation path (`TokenRotated`) and hash persistence for both hooks (namespaced + generated cluster variants).

Live e2e on a self-managed **GitLab 18.11.5-ee** group (provider out-of-cluster against a kwok control plane): created a group hook with a token, then rotated **only** the referenced secret. The reconciler detected the change and issued an `Update` — `status.atProvider.tokenHash` moved from `sha256(v1)` to `sha256(v2)` — confirming the previously-broken path now works. All sandbox resources were cleaned up afterward.

### Delete by external-name (group + project)
`Delete` used `status.atProvider.ID` for the hook id while `Observe`/`Update` derive it from the external-name. If the resource was deleted before a successful `Observe` populated `atProvider.ID`, that id is `0` and `Delete` would call `DeleteHook(..., 0)`, orphaning the real webhook. `Delete` now parses the hook id from the external-name, matching `Observe`/`Update`.
