### PR TITLE
chore(renovate): group dependency updates to reduce PR volume

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,15 +5,28 @@
     "helpers:pinGitHubActionDigests",
     ":semanticCommits"
   ],
-  "crossplane": {
-    "managerFilePatterns": ["/(^|/)example/.*\\.ya?ml$/"]
-  },
+  "automergeStrategy": "squash",
+  "rebaseWhen": "auto",
+  "minimumReleaseAge": "1 day",
+  "enabledManagers": ["gomod", "github-actions", "dockerfile", "crossplane"],
   "packageRules": [
     {
-      "matchManagers": ["crossplane"],
-      "matchFileNames": ["example/**"],
-      "groupName": "examples"
+      "matchUpdateTypes": ["patch", "minor", "digest", "pinDigest"],
+      "groupName": "all minor and patch",
+      "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "groupName": "all major",
+      "automerge": false
+    },
+    {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ],
-  "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"]
+  "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
+  "pinDigests": true
 }


### PR DESCRIPTION
## What this does

Reduces Renovate PR volume so routine dependency updates arrive as a couple of grouped PRs instead of one per package.

### Changes to `renovate.json`

- **Grouping:** all `patch`/`minor`/`digest` updates land in a single **"all minor and patch"** PR (automerged); all `major` updates land in a single **"all major"** PR (manual review).
- Disable `major` bumps of **indirect** Go modules.
- `minimumReleaseAge: 1 day`, `automergeStrategy: squash`, `rebaseWhen: auto`, `pinDigests: true`.
- Restrict `enabledManagers` to the ones this repo actually uses: `gomod` (root + `tools/`), `github-actions`, `dockerfile` (`cluster/images/provider-gitlab/Dockerfile`), and `crossplane`.
- Remove the old `crossplane` manager block: `crossplane.managerFilePatterns` is not a valid config option (fails `renovate-config-validator`), and its `example/` path never matched the repo's `examples/` directory — it was dead config. The crossplane manager keeps its default file matching.
- Keep `config:recommended`, `helpers:pinGitHubActionDigests`, and `:semanticCommits`.

Validated with `renovate-config-validator`.

### Note on automerge

The "all minor and patch" group is set to `automerge: true`. This only takes effect if branch protection allows Renovate to merge once required checks pass; major updates always require manual review. Happy to drop automerge if maintainers prefer manual merges for everything.
