### PR TITLE
docs: remove misleading publishConnectionDetailsTo references (#266)

### DIFF
--- a/apis/cluster/groups/v1alpha1/zz_runner_types.go
+++ b/apis/cluster/groups/v1alpha1/zz_runner_types.go
@@ -113,7 +113,7 @@ type RunnerStatus struct {
 // Group runners can execute CI/CD jobs for all projects within the associated group
 // and provide a way to share runner resources across multiple projects.
 //
-// IMPORTANT: You MUST specify either writeConnectionSecretToRef or publishConnectionDetailsTo
+// IMPORTANT: You MUST specify writeConnectionSecretToRef
 // to receive the runner token. Without the token, the runner cannot be registered and is unusable.
 // The token is required to configure the actual GitLab Runner agent.
 //

--- a/apis/cluster/instance/v1alpha1/zz_license_types.go
+++ b/apis/cluster/instance/v1alpha1/zz_license_types.go
@@ -165,7 +165,7 @@ type LicenseStatus struct {
 // WARNING: This resource should not be used multiple times for the same GitLab instance.
 //
 // IMPORTANT: If you choose to use a LicenseSecretRef OR a LicenseEndpointURL / LicenseEndpointURLSecretRef,
-// You must configure the writeConnectionSecretToRef or publishConnectionDetailsTo to receive the license key.
+// You must configure the writeConnectionSecretToRef to receive the license key.
 //
 // Example usage:
 //

--- a/apis/cluster/instance/v1alpha1/zz_runner_types.go
+++ b/apis/cluster/instance/v1alpha1/zz_runner_types.go
@@ -74,7 +74,7 @@ type RunnerStatus struct {
 // Instance runners can execute CI/CD jobs exclusively for the associated instance
 // and provide dedicated runner resources for a single instance.
 //
-// IMPORTANT: You MUST specify either writeConnectionSecretToRef or publishConnectionDetailsTo
+// IMPORTANT: You MUST specify writeConnectionSecretToRef
 // to receive the runner token. Without the token, the runner cannot be registered and is unusable.
 // The token is required to configure the actual GitLab Runner agent.
 //

--- a/apis/cluster/projects/v1alpha1/zz_runner_types.go
+++ b/apis/cluster/projects/v1alpha1/zz_runner_types.go
@@ -123,7 +123,7 @@ type RunnerStatus struct {
 // Project runners can execute CI/CD jobs exclusively for the associated project
 // and provide dedicated runner resources for a single project.
 //
-// IMPORTANT: You MUST specify either writeConnectionSecretToRef or publishConnectionDetailsTo
+// IMPORTANT: You MUST specify writeConnectionSecretToRef
 // to receive the runner token. Without the token, the runner cannot be registered and is unusable.
 // The token is required to configure the actual GitLab Runner agent.
 //

--- a/apis/namespaced/groups/v1alpha1/runner_types.go
+++ b/apis/namespaced/groups/v1alpha1/runner_types.go
@@ -111,7 +111,7 @@ type RunnerStatus struct {
 // Group runners can execute CI/CD jobs for all projects within the associated group
 // and provide a way to share runner resources across multiple projects.
 //
-// IMPORTANT: You MUST specify either writeConnectionSecretToRef or publishConnectionDetailsTo
+// IMPORTANT: You MUST specify writeConnectionSecretToRef
 // to receive the runner token. Without the token, the runner cannot be registered and is unusable.
 // The token is required to configure the actual GitLab Runner agent.
 //

--- a/apis/namespaced/instance/v1alpha1/license_types.go
+++ b/apis/namespaced/instance/v1alpha1/license_types.go
@@ -163,7 +163,7 @@ type LicenseStatus struct {
 // WARNING: This resource should not be used multiple times for the same GitLab instance.
 //
 // IMPORTANT: If you choose to use a LicenseSecretRef OR a LicenseEndpointURL / LicenseEndpointURLSecretRef,
-// You must configure the writeConnectionSecretToRef or publishConnectionDetailsTo to receive the license key.
+// You must configure the writeConnectionSecretToRef to receive the license key.
 //
 // Example usage:
 //

--- a/apis/namespaced/instance/v1alpha1/runner_types.go
+++ b/apis/namespaced/instance/v1alpha1/runner_types.go
@@ -72,7 +72,7 @@ type RunnerStatus struct {
 // Instance runners can execute CI/CD jobs exclusively for the associated instance
 // and provide dedicated runner resources for a single instance.
 //
-// IMPORTANT: You MUST specify either writeConnectionSecretToRef or publishConnectionDetailsTo
+// IMPORTANT: You MUST specify writeConnectionSecretToRef
 // to receive the runner token. Without the token, the runner cannot be registered and is unusable.
 // The token is required to configure the actual GitLab Runner agent.
 //

--- a/apis/namespaced/projects/v1alpha1/runner_types.go
+++ b/apis/namespaced/projects/v1alpha1/runner_types.go
@@ -121,7 +121,7 @@ type RunnerStatus struct {
 // Project runners can execute CI/CD jobs exclusively for the associated project
 // and provide dedicated runner resources for a single project.
 //
-// IMPORTANT: You MUST specify either writeConnectionSecretToRef or publishConnectionDetailsTo
+// IMPORTANT: You MUST specify writeConnectionSecretToRef
 // to receive the runner token. Without the token, the runner cannot be registered and is unusable.
 // The token is required to configure the actual GitLab Runner agent.
 //

--- a/package/crds/groups.gitlab.crossplane.io_runners.yaml
+++ b/package/crds/groups.gitlab.crossplane.io_runners.yaml
@@ -43,15 +43,15 @@ spec:
         description: "A Runner is a managed resource that represents a GitLab Runner
           linked to a group.\nGroup runners can execute CI/CD jobs for all projects
           within the associated group\nand provide a way to share runner resources
-          across multiple projects.\n\nIMPORTANT: You MUST specify either writeConnectionSecretToRef
-          or publishConnectionDetailsTo\nto receive the runner token. Without the
-          token, the runner cannot be registered and is unusable.\nThe token is required
-          to configure the actual GitLab Runner agent.\n\nExample usage:\n\n\tspec:\n\t
-          \ writeConnectionSecretToRef:\n\t    name: my-runner-token\n\t    namespace:
-          default\n\nWhen a Runner is created, it generates a runner token that must
-          be used\nto register the actual GitLab Runner agent with the GitLab instance.\nThe
-          runner token is made available through Kubernetes secrets via connection
-          details.\n\nGitLab API docs:\nhttps://docs.gitlab.com/ee/api/users.html#create-a-runner\nhttps://docs.gitlab.com/ee/api/runners.html"
+          across multiple projects.\n\nIMPORTANT: You MUST specify writeConnectionSecretToRef\nto
+          receive the runner token. Without the token, the runner cannot be registered
+          and is unusable.\nThe token is required to configure the actual GitLab Runner
+          agent.\n\nExample usage:\n\n\tspec:\n\t  writeConnectionSecretToRef:\n\t
+          \   name: my-runner-token\n\t    namespace: default\n\nWhen a Runner is
+          created, it generates a runner token that must be used\nto register the
+          actual GitLab Runner agent with the GitLab instance.\nThe runner token is
+          made available through Kubernetes secrets via connection details.\n\nGitLab
+          API docs:\nhttps://docs.gitlab.com/ee/api/users.html#create-a-runner\nhttps://docs.gitlab.com/ee/api/runners.html"
         properties:
           apiVersion:
             description: |-

--- a/package/crds/groups.gitlab.m.crossplane.io_runners.yaml
+++ b/package/crds/groups.gitlab.m.crossplane.io_runners.yaml
@@ -43,15 +43,15 @@ spec:
         description: "A Runner is a managed resource that represents a GitLab Runner
           linked to a group.\nGroup runners can execute CI/CD jobs for all projects
           within the associated group\nand provide a way to share runner resources
-          across multiple projects.\n\nIMPORTANT: You MUST specify either writeConnectionSecretToRef
-          or publishConnectionDetailsTo\nto receive the runner token. Without the
-          token, the runner cannot be registered and is unusable.\nThe token is required
-          to configure the actual GitLab Runner agent.\n\nExample usage:\n\n\tspec:\n\t
-          \ writeConnectionSecretToRef:\n\t    name: my-runner-token\n\t    namespace:
-          default\n\nWhen a Runner is created, it generates a runner token that must
-          be used\nto register the actual GitLab Runner agent with the GitLab instance.\nThe
-          runner token is made available through Kubernetes secrets via connection
-          details.\n\nGitLab API docs:\nhttps://docs.gitlab.com/ee/api/users.html#create-a-runner\nhttps://docs.gitlab.com/ee/api/runners.html"
+          across multiple projects.\n\nIMPORTANT: You MUST specify writeConnectionSecretToRef\nto
+          receive the runner token. Without the token, the runner cannot be registered
+          and is unusable.\nThe token is required to configure the actual GitLab Runner
+          agent.\n\nExample usage:\n\n\tspec:\n\t  writeConnectionSecretToRef:\n\t
+          \   name: my-runner-token\n\t    namespace: default\n\nWhen a Runner is
+          created, it generates a runner token that must be used\nto register the
+          actual GitLab Runner agent with the GitLab instance.\nThe runner token is
+          made available through Kubernetes secrets via connection details.\n\nGitLab
+          API docs:\nhttps://docs.gitlab.com/ee/api/users.html#create-a-runner\nhttps://docs.gitlab.com/ee/api/runners.html"
         properties:
           apiVersion:
             description: |-

--- a/package/crds/instance.gitlab.crossplane.io_licenses.yaml
+++ b/package/crds/instance.gitlab.crossplane.io_licenses.yaml
@@ -38,9 +38,9 @@ spec:
           linked to a instance.\n\nWARNING: This resource should not be used multiple
           times for the same GitLab instance.\n\nIMPORTANT: If you choose to use a
           LicenseSecretRef OR a LicenseEndpointURL / LicenseEndpointURLSecretRef,\nYou
-          must configure the writeConnectionSecretToRef or publishConnectionDetailsTo
-          to receive the license key.\n\nExample usage:\n\n\tspec:\n\t  writeConnectionSecretToRef:\n\t
-          \   name: my-license-key\n\t    namespace: default"
+          must configure the writeConnectionSecretToRef to receive the license key.\n\nExample
+          usage:\n\n\tspec:\n\t  writeConnectionSecretToRef:\n\t    name: my-license-key\n\t
+          \   namespace: default"
         properties:
           apiVersion:
             description: |-

--- a/package/crds/instance.gitlab.crossplane.io_runners.yaml
+++ b/package/crds/instance.gitlab.crossplane.io_runners.yaml
@@ -43,15 +43,15 @@ spec:
         description: "A Runner is a managed resource that represents a GitLab Runner
           linked to a instance.\nInstance runners can execute CI/CD jobs exclusively
           for the associated instance\nand provide dedicated runner resources for
-          a single instance.\n\nIMPORTANT: You MUST specify either writeConnectionSecretToRef
-          or publishConnectionDetailsTo\nto receive the runner token. Without the
-          token, the runner cannot be registered and is unusable.\nThe token is required
-          to configure the actual GitLab Runner agent.\n\nExample usage:\n\n\tspec:\n\t
-          \ writeConnectionSecretToRef:\n\t    name: my-runner-token\n\t    namespace:
-          default\n\nWhen a Runner is created, it generates a runner token that must
-          be used\nto register the actual GitLab Runner agent with the GitLab instance.\nThe
-          runner token is made available through Kubernetes secrets via connection
-          details.\n\nGitLab API docs:\nhttps://docs.gitlab.com/ee/api/users.html#create-a-runner\nhttps://docs.gitlab.com/ee/api/runners.html"
+          a single instance.\n\nIMPORTANT: You MUST specify writeConnectionSecretToRef\nto
+          receive the runner token. Without the token, the runner cannot be registered
+          and is unusable.\nThe token is required to configure the actual GitLab Runner
+          agent.\n\nExample usage:\n\n\tspec:\n\t  writeConnectionSecretToRef:\n\t
+          \   name: my-runner-token\n\t    namespace: default\n\nWhen a Runner is
+          created, it generates a runner token that must be used\nto register the
+          actual GitLab Runner agent with the GitLab instance.\nThe runner token is
+          made available through Kubernetes secrets via connection details.\n\nGitLab
+          API docs:\nhttps://docs.gitlab.com/ee/api/users.html#create-a-runner\nhttps://docs.gitlab.com/ee/api/runners.html"
         properties:
           apiVersion:
             description: |-

--- a/package/crds/instance.gitlab.m.crossplane.io_licenses.yaml
+++ b/package/crds/instance.gitlab.m.crossplane.io_licenses.yaml
@@ -38,9 +38,9 @@ spec:
           linked to a instance.\n\nWARNING: This resource should not be used multiple
           times for the same GitLab instance.\n\nIMPORTANT: If you choose to use a
           LicenseSecretRef OR a LicenseEndpointURL / LicenseEndpointURLSecretRef,\nYou
-          must configure the writeConnectionSecretToRef or publishConnectionDetailsTo
-          to receive the license key.\n\nExample usage:\n\n\tspec:\n\t  writeConnectionSecretToRef:\n\t
-          \   name: my-license-key\n\t    namespace: default"
+          must configure the writeConnectionSecretToRef to receive the license key.\n\nExample
+          usage:\n\n\tspec:\n\t  writeConnectionSecretToRef:\n\t    name: my-license-key\n\t
+          \   namespace: default"
         properties:
           apiVersion:
             description: |-

--- a/package/crds/instance.gitlab.m.crossplane.io_runners.yaml
+++ b/package/crds/instance.gitlab.m.crossplane.io_runners.yaml
@@ -43,15 +43,15 @@ spec:
         description: "A Runner is a managed resource that represents a GitLab Runner
           linked to a instance.\nInstance runners can execute CI/CD jobs exclusively
           for the associated instance\nand provide dedicated runner resources for
-          a single instance.\n\nIMPORTANT: You MUST specify either writeConnectionSecretToRef
-          or publishConnectionDetailsTo\nto receive the runner token. Without the
-          token, the runner cannot be registered and is unusable.\nThe token is required
-          to configure the actual GitLab Runner agent.\n\nExample usage:\n\n\tspec:\n\t
-          \ writeConnectionSecretToRef:\n\t    name: my-runner-token\n\t    namespace:
-          default\n\nWhen a Runner is created, it generates a runner token that must
-          be used\nto register the actual GitLab Runner agent with the GitLab instance.\nThe
-          runner token is made available through Kubernetes secrets via connection
-          details.\n\nGitLab API docs:\nhttps://docs.gitlab.com/ee/api/users.html#create-a-runner\nhttps://docs.gitlab.com/ee/api/runners.html"
+          a single instance.\n\nIMPORTANT: You MUST specify writeConnectionSecretToRef\nto
+          receive the runner token. Without the token, the runner cannot be registered
+          and is unusable.\nThe token is required to configure the actual GitLab Runner
+          agent.\n\nExample usage:\n\n\tspec:\n\t  writeConnectionSecretToRef:\n\t
+          \   name: my-runner-token\n\t    namespace: default\n\nWhen a Runner is
+          created, it generates a runner token that must be used\nto register the
+          actual GitLab Runner agent with the GitLab instance.\nThe runner token is
+          made available through Kubernetes secrets via connection details.\n\nGitLab
+          API docs:\nhttps://docs.gitlab.com/ee/api/users.html#create-a-runner\nhttps://docs.gitlab.com/ee/api/runners.html"
         properties:
           apiVersion:
             description: |-

--- a/package/crds/projects.gitlab.crossplane.io_runners.yaml
+++ b/package/crds/projects.gitlab.crossplane.io_runners.yaml
@@ -43,15 +43,15 @@ spec:
         description: "A Runner is a managed resource that represents a GitLab Runner
           linked to a project.\nProject runners can execute CI/CD jobs exclusively
           for the associated project\nand provide dedicated runner resources for a
-          single project.\n\nIMPORTANT: You MUST specify either writeConnectionSecretToRef
-          or publishConnectionDetailsTo\nto receive the runner token. Without the
-          token, the runner cannot be registered and is unusable.\nThe token is required
-          to configure the actual GitLab Runner agent.\n\nExample usage:\n\n\tspec:\n\t
-          \ writeConnectionSecretToRef:\n\t    name: my-runner-token\n\t    namespace:
-          default\n\nWhen a Runner is created, it generates a runner token that must
-          be used\nto register the actual GitLab Runner agent with the GitLab instance.\nThe
-          runner token is made available through Kubernetes secrets via connection
-          details.\n\nGitLab API docs:\nhttps://docs.gitlab.com/ee/api/users.html#create-a-runner\nhttps://docs.gitlab.com/ee/api/runners.html"
+          single project.\n\nIMPORTANT: You MUST specify writeConnectionSecretToRef\nto
+          receive the runner token. Without the token, the runner cannot be registered
+          and is unusable.\nThe token is required to configure the actual GitLab Runner
+          agent.\n\nExample usage:\n\n\tspec:\n\t  writeConnectionSecretToRef:\n\t
+          \   name: my-runner-token\n\t    namespace: default\n\nWhen a Runner is
+          created, it generates a runner token that must be used\nto register the
+          actual GitLab Runner agent with the GitLab instance.\nThe runner token is
+          made available through Kubernetes secrets via connection details.\n\nGitLab
+          API docs:\nhttps://docs.gitlab.com/ee/api/users.html#create-a-runner\nhttps://docs.gitlab.com/ee/api/runners.html"
         properties:
           apiVersion:
             description: |-

--- a/package/crds/projects.gitlab.m.crossplane.io_runners.yaml
+++ b/package/crds/projects.gitlab.m.crossplane.io_runners.yaml
@@ -43,15 +43,15 @@ spec:
         description: "A Runner is a managed resource that represents a GitLab Runner
           linked to a project.\nProject runners can execute CI/CD jobs exclusively
           for the associated project\nand provide dedicated runner resources for a
-          single project.\n\nIMPORTANT: You MUST specify either writeConnectionSecretToRef
-          or publishConnectionDetailsTo\nto receive the runner token. Without the
-          token, the runner cannot be registered and is unusable.\nThe token is required
-          to configure the actual GitLab Runner agent.\n\nExample usage:\n\n\tspec:\n\t
-          \ writeConnectionSecretToRef:\n\t    name: my-runner-token\n\t    namespace:
-          default\n\nWhen a Runner is created, it generates a runner token that must
-          be used\nto register the actual GitLab Runner agent with the GitLab instance.\nThe
-          runner token is made available through Kubernetes secrets via connection
-          details.\n\nGitLab API docs:\nhttps://docs.gitlab.com/ee/api/users.html#create-a-runner\nhttps://docs.gitlab.com/ee/api/runners.html"
+          single project.\n\nIMPORTANT: You MUST specify writeConnectionSecretToRef\nto
+          receive the runner token. Without the token, the runner cannot be registered
+          and is unusable.\nThe token is required to configure the actual GitLab Runner
+          agent.\n\nExample usage:\n\n\tspec:\n\t  writeConnectionSecretToRef:\n\t
+          \   name: my-runner-token\n\t    namespace: default\n\nWhen a Runner is
+          created, it generates a runner token that must be used\nto register the
+          actual GitLab Runner agent with the GitLab instance.\nThe runner token is
+          made available through Kubernetes secrets via connection details.\n\nGitLab
+          API docs:\nhttps://docs.gitlab.com/ee/api/users.html#create-a-runner\nhttps://docs.gitlab.com/ee/api/runners.html"
         properties:
           apiVersion:
             description: |-

--- a/pkg/cluster/controller/groups/runners/zz_controller.go
+++ b/pkg/cluster/controller/groups/runners/zz_controller.go
@@ -55,7 +55,7 @@ const (
 	errResetFailed             = "cannot reset Gitlab Runner authentication token"
 	errMissingGroupID          = "missing Spec.ForProvider.GroupID"
 	errMissingExternalName     = "external name annotation not found"
-	errMissingConnectionSecret = "writeConnectionSecretToRef or publishConnectionDetailsTo must be specified to receive the runner token"
+	errMissingConnectionSecret = "writeConnectionSecretToRef must be specified to receive the runner token"
 )
 
 // SetupRunner adds a controller that reconciles runners.

--- a/pkg/cluster/controller/instance/runners/zz_controller.go
+++ b/pkg/cluster/controller/instance/runners/zz_controller.go
@@ -53,7 +53,7 @@ const (
 	errDeleteFailed            = "cannot delete Gitlab Runner"
 	errResetFailed             = "cannot reset Gitlab Runner authentication token"
 	errMissingExternalName     = "external name annotation not found"
-	errMissingConnectionSecret = "writeConnectionSecretToRef or publishConnectionDetailsTo must be specified to receive the runner token"
+	errMissingConnectionSecret = "writeConnectionSecretToRef must be specified to receive the runner token"
 )
 
 // SetupRunner adds a controller that reconciles instance runners.

--- a/pkg/cluster/controller/projects/runners/zz_controller.go
+++ b/pkg/cluster/controller/projects/runners/zz_controller.go
@@ -55,7 +55,7 @@ const (
 	errResetFailed             = "cannot reset Gitlab Runner authentication token"
 	errMissingProjectID        = "missing Spec.ForProvider.ProjectID"
 	errMissingExternalName     = "external name annotation not found"
-	errMissingConnectionSecret = "writeConnectionSecretToRef or publishConnectionDetailsTo must be specified to receive the runner token"
+	errMissingConnectionSecret = "writeConnectionSecretToRef must be specified to receive the runner token"
 )
 
 // SetupRunner adds a controller that reconciles projects runners.

--- a/pkg/namespaced/controller/groups/runners/controller.go
+++ b/pkg/namespaced/controller/groups/runners/controller.go
@@ -53,7 +53,7 @@ const (
 	errResetFailed             = "cannot reset Gitlab Runner authentication token"
 	errMissingGroupID          = "missing Spec.ForProvider.GroupID"
 	errMissingExternalName     = "external name annotation not found"
-	errMissingConnectionSecret = "writeConnectionSecretToRef or publishConnectionDetailsTo must be specified to receive the runner token"
+	errMissingConnectionSecret = "writeConnectionSecretToRef must be specified to receive the runner token"
 )
 
 // SetupRunner adds a controller that reconciles runners.

--- a/pkg/namespaced/controller/instance/runners/controller.go
+++ b/pkg/namespaced/controller/instance/runners/controller.go
@@ -51,7 +51,7 @@ const (
 	errDeleteFailed            = "cannot delete Gitlab Runner"
 	errResetFailed             = "cannot reset Gitlab Runner authentication token"
 	errMissingExternalName     = "external name annotation not found"
-	errMissingConnectionSecret = "writeConnectionSecretToRef or publishConnectionDetailsTo must be specified to receive the runner token"
+	errMissingConnectionSecret = "writeConnectionSecretToRef must be specified to receive the runner token"
 )
 
 // SetupRunner adds a controller that reconciles instance runners.

--- a/pkg/namespaced/controller/projects/runners/controller.go
+++ b/pkg/namespaced/controller/projects/runners/controller.go
@@ -53,7 +53,7 @@ const (
 	errResetFailed             = "cannot reset Gitlab Runner authentication token"
 	errMissingProjectID        = "missing Spec.ForProvider.ProjectID"
 	errMissingExternalName     = "external name annotation not found"
-	errMissingConnectionSecret = "writeConnectionSecretToRef or publishConnectionDetailsTo must be specified to receive the runner token"
+	errMissingConnectionSecret = "writeConnectionSecretToRef must be specified to receive the runner token"
 )
 
 // SetupRunner adds a controller that reconciles projects runners.


### PR DESCRIPTION
## What this does

Fixes #266 by removing the misleading `publishConnectionDetailsTo` references.

`publishConnectionDetailsTo` is a **Crossplane v1** feature (backed by the alpha External Secret Stores mechanism). It does **not** exist in the Crossplane **v2** managed-resource spec this provider uses — neither `ManagedResourceSpec` (namespaced) nor `ClusterManagedResourceSpec` expose it; both only have `writeConnectionSecretToRef`. Setting `publishConnectionDetailsTo` is therefore silently pruned by the API server (no error, no effect), which is what the issue observed.

Since the field cannot be supported on Crossplane v2, this takes the "delete the misleading comments" path from the issue's Definition of Done.

### Changes
- Removed the `... or publishConnectionDetailsTo` wording from:
  - the Runner Kind doc comments (project/group/instance) → also updates the generated CRD descriptions
  - the License Kind doc comment
  - the `errMissingConnectionSecret` message in the three runner controllers
- Regenerated the cluster (`zz_`) mirrors and CRDs. **No schema changes** (description text only).

### Testing
`go build ./...`, full `go test ./...`, and `golangci-lint` all pass.
