### PR TITLE
fix(providerconfig): scope credentials secrets to namespace

### DIFF
--- a/pkg/common/gitlab.go
+++ b/pkg/common/gitlab.go
@@ -170,17 +170,17 @@ func UseProvicerConfig(ctx context.Context, c client.Client, mg resource.ModernM
 		if err := c.Get(ctx, types.NamespacedName{Name: pcRef.Name}, cpc); err != nil {
 			return nil, errors.Wrap(err, "cannot get referenced ClusterProviderConfig")
 		}
-		return buildConfigFromSpec(ctx, c, mg, cpc.Spec)
+		return buildConfigFromSpec(ctx, c, mg, cpc.Spec, nil)
 	default: // "ProviderConfig" or empty (default)
 		pc := &namespacedV1Beta1.ProviderConfig{}
 		if err := c.Get(ctx, types.NamespacedName{Name: pcRef.Name, Namespace: mg.GetNamespace()}, pc); err != nil {
 			return nil, errors.Wrap(err, "cannot get referenced ProviderConfig")
 		}
-		return buildConfigFromSpec(ctx, c, mg, pc.Spec)
+		return buildConfigFromSpec(ctx, c, mg, pc.Spec, &pc.Namespace)
 	}
 }
 
-func buildConfigFromSpec(ctx context.Context, c client.Client, mg resource.ModernManaged, spec namespacedV1Beta1.ProviderConfigSpec) (*Config, error) {
+func buildConfigFromSpec(ctx context.Context, c client.Client, mg resource.ModernManaged, spec namespacedV1Beta1.ProviderConfigSpec, secretNamespace *string) (*Config, error) {
 	t := resource.NewProviderConfigUsageTracker(c, &namespacedV1Beta1.ProviderConfigUsage{})
 	if err := t.Track(ctx, mg); err != nil {
 		return nil, errors.Wrap(err, "cannot track ProviderConfig usage")
@@ -192,7 +192,12 @@ func buildConfigFromSpec(ctx context.Context, c client.Client, mg resource.Moder
 			return nil, errors.New("no credentials secret referenced")
 		}
 
-		token, err := GetTokenValueFromSecret(ctx, c, mg, spec.Credentials.SecretRef)
+		secretRef := spec.Credentials.SecretRef.DeepCopy()
+		if secretNamespace != nil {
+			secretRef.SecretReference.Namespace = *secretNamespace
+		}
+
+		token, err := GetTokenValueFromSecret(ctx, c, mg, secretRef)
 		if err != nil {
 			return nil, err
 		}
@@ -202,7 +207,7 @@ func buildConfigFromSpec(ctx context.Context, c client.Client, mg resource.Moder
 			Token:                *token,
 			InsecureSkipVerify:   ptr.Deref(spec.InsecureSkipVerify, false),
 			AuthMethod:           spec.Credentials.Method,
-			CredentialsSecretRef: spec.Credentials.SecretRef,
+			CredentialsSecretRef: secretRef,
 		}, nil
 	default:
 		return nil, errors.Errorf("credentials source %s is not currently supported", s)

--- a/pkg/common/helper_test.go
+++ b/pkg/common/helper_test.go
@@ -31,6 +31,8 @@ import (
 
 	clustergroupsv1alpha1 "github.com/crossplane-contrib/provider-gitlab/apis/cluster/groups/v1alpha1"
 	legacyv1beta1 "github.com/crossplane-contrib/provider-gitlab/apis/cluster/v1beta1"
+	namespacedgroupsv1alpha1 "github.com/crossplane-contrib/provider-gitlab/apis/namespaced/groups/v1alpha1"
+	namespacedv1beta1 "github.com/crossplane-contrib/provider-gitlab/apis/namespaced/v1beta1"
 )
 
 type mockManagedResource struct {
@@ -218,6 +220,105 @@ func TestUseLegacyProviderConfigSetsCredentialsSecretRef(t *testing.T) {
 
 	if diff := cmp.Diff(selector, cfg.CredentialsSecretRef); diff != "" {
 		t.Fatalf("CredentialsSecretRef mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestUseProviderConfigForcesCredentialsSecretNamespace(t *testing.T) {
+	const (
+		managedNamespace = "tenant-a"
+		otherNamespace   = "tenant-b"
+		testToken        = "test-token-value"
+	)
+
+	mg := &namespacedgroupsv1alpha1.Group{ObjectMeta: metav1.ObjectMeta{Namespace: managedNamespace}}
+	mg.SetProviderConfigReference(&v2.ProviderConfigReference{Kind: "ProviderConfig", Name: "test-provider-config"})
+	selector := &v2.SecretKeySelector{
+		Key:             "token",
+		SecretReference: v2.SecretReference{Name: "test-secret", Namespace: otherNamespace},
+	}
+
+	var secretKey client.ObjectKey
+	kube := &test.MockClient{
+		MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+			switch o := obj.(type) {
+			case *namespacedv1beta1.ProviderConfig:
+				*o = namespacedv1beta1.ProviderConfig{
+					ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace},
+					Spec: namespacedv1beta1.ProviderConfigSpec{
+						Credentials: namespacedv1beta1.ProviderCredentials{
+							Source: v2.CredentialsSourceSecret,
+							CommonCredentialSelectors: v2.CommonCredentialSelectors{
+								SecretRef: selector,
+							},
+						},
+					},
+				}
+			case *corev1.Secret:
+				secretKey = key
+				*o = corev1.Secret{Data: map[string][]byte{"token": []byte(testToken)}}
+			}
+			return nil
+		},
+		MockCreate: test.NewMockCreateFn(nil),
+	}
+
+	cfg, err := UseProvicerConfig(context.Background(), kube, mg)
+	if err != nil {
+		t.Fatalf("UseProvicerConfig() error = %v", err)
+	}
+
+	want := client.ObjectKey{Name: "test-secret", Namespace: managedNamespace}
+	if diff := cmp.Diff(want, secretKey); diff != "" {
+		t.Fatalf("secret key mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(managedNamespace, cfg.CredentialsSecretRef.SecretReference.Namespace); diff != "" {
+		t.Fatalf("credentials secret namespace mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(otherNamespace, selector.SecretReference.Namespace); diff != "" {
+		t.Fatalf("source selector namespace mutated (-want +got):\n%s", diff)
+	}
+}
+
+func TestUseClusterProviderConfigPreservesCredentialsSecretNamespace(t *testing.T) {
+	const secretNamespace = "credentials"
+
+	mg := &namespacedgroupsv1alpha1.Group{ObjectMeta: metav1.ObjectMeta{Namespace: "tenant-a"}}
+	mg.SetProviderConfigReference(&v2.ProviderConfigReference{Kind: "ClusterProviderConfig", Name: "test-provider-config"})
+
+	var secretKey client.ObjectKey
+	kube := &test.MockClient{
+		MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+			switch o := obj.(type) {
+			case *namespacedv1beta1.ClusterProviderConfig:
+				*o = namespacedv1beta1.ClusterProviderConfig{
+					Spec: namespacedv1beta1.ProviderConfigSpec{
+						Credentials: namespacedv1beta1.ProviderCredentials{
+							Source: v2.CredentialsSourceSecret,
+							CommonCredentialSelectors: v2.CommonCredentialSelectors{
+								SecretRef: &v2.SecretKeySelector{
+									Key:             "token",
+									SecretReference: v2.SecretReference{Name: "test-secret", Namespace: secretNamespace},
+								},
+							},
+						},
+					},
+				}
+			case *corev1.Secret:
+				secretKey = key
+				*o = corev1.Secret{Data: map[string][]byte{"token": []byte("test-token-value")}}
+			}
+			return nil
+		},
+		MockCreate: test.NewMockCreateFn(nil),
+	}
+
+	if _, err := UseProvicerConfig(context.Background(), kube, mg); err != nil {
+		t.Fatalf("UseProvicerConfig() error = %v", err)
+	}
+
+	want := client.ObjectKey{Name: "test-secret", Namespace: secretNamespace}
+	if diff := cmp.Diff(want, secretKey); diff != "" {
+		t.Fatalf("secret key mismatch (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
## Summary
- force namespaced ProviderConfig credential secrets to its own namespace
- preserve explicit secret namespaces for ClusterProviderConfig
- avoid mutating the source secret selector

## Testing
- `go test ./pkg/common -count=1`
- `git diff --check`

Security impact will be coordinated privately 